### PR TITLE
Adding a closure holder

### DIFF
--- a/include/xtl/xclosure.hpp
+++ b/include/xtl/xclosure.hpp
@@ -16,9 +16,9 @@
 
 namespace xtl
 {
-    /***********
-     * closure *
-     ***********/
+    /****************
+     * closure_type *
+     ****************/
 
     template <class S>
     struct closure_type
@@ -46,9 +46,9 @@ namespace xtl
     template <class S>
     using const_closure_type_t = typename const_closure_type<S>::type;
 
-    /***************
-     * ptr_closure *
-     ***************/
+    /****************************
+     * ptr_closure_closure_type *
+     ****************************/
 
     template <class S>
     struct ptr_closure_type
@@ -75,6 +75,170 @@ namespace xtl
 
     template <class S>
     using const_ptr_closure_type_t = typename const_ptr_closure_type<S>::type;
+
+    /*******************
+     * closure_wrapper *
+     *******************/
+
+    template <class CT>
+    class closure_wrapper
+    {
+    public:
+
+        using value_type = std::decay_t<CT>;
+        using closure_type = CT;
+        using self_type = closure_wrapper<CT>;
+
+        using reference = std::conditional_t<
+          std::is_const<std::remove_reference_t<CT>>::value,
+          const value_type&, value_type&
+        >;
+
+        closure_wrapper(value_type&& e);
+        closure_wrapper(reference e);
+
+        template <class T>
+        self_type& operator=(T&&);
+
+        operator closure_type() noexcept;
+        closure_type get() & noexcept;
+        closure_type get() const & noexcept;
+        closure_type get() && noexcept;        
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+
+        using storing_type = xtl::ptr_closure_type_t<CT>;
+        storing_type m_wrappee;
+
+        template <class T>
+        std::enable_if_t<std::is_pointer<T>::value, std::add_lvalue_reference_t<std::remove_pointer_t<T>>>
+        deref(T val) const;
+
+        template <class T>
+        std::enable_if_t<!std::is_pointer<T>::value, std::add_lvalue_reference_t<T>>
+        deref(T& val) const;
+
+        template <class T, class CTA>
+        std::enable_if_t<std::is_pointer<T>::value, T>
+        get_storage_init(CTA&& e) const;
+
+        template <class T, class CTA>
+        std::enable_if_t<!std::is_pointer<T>::value, T>
+        get_storage_init(CTA&& e) const;
+    };
+
+    template <class CT>
+    inline closure_wrapper<CT>::closure_wrapper(value_type&& e)
+        : m_wrappee(get_storage_init<storing_type>(std::move(e)))
+    {
+    }
+
+    template <class CT>
+    inline closure_wrapper<CT>::closure_wrapper(reference e)
+        : m_wrappee(get_storage_init<storing_type>(e))
+    {
+    }
+
+    template <class CT>
+    template <class T>
+    inline auto closure_wrapper<CT>::operator=(T&& t)
+        -> self_type& 
+    {
+        deref(m_wrappee) = std::forward<T>(t);
+        return *this;
+    }
+
+    template <class CT>
+    inline closure_wrapper<CT>::operator typename closure_wrapper<CT>::closure_type() noexcept
+    {
+        return deref(m_wrappee);
+    }
+
+    template <class CT>
+    inline auto closure_wrapper<CT>::get() & noexcept -> closure_type
+    {
+        return deref(m_wrappee);
+    }
+
+    template <class CT>
+    inline auto closure_wrapper<CT>::get() const & noexcept -> closure_type
+    {
+        return deref(m_wrappee);
+    }
+
+    template <class CT>
+    inline auto closure_wrapper<CT>::get() && noexcept -> closure_type
+    {
+        return deref(m_wrappee);
+    }
+
+    template <class CT>
+    template <class T>
+    inline std::enable_if_t<std::is_pointer<T>::value, std::add_lvalue_reference_t<std::remove_pointer_t<T>>>
+    closure_wrapper<CT>::deref(T val) const
+    {
+        return *val;
+    }
+
+    template <class CT>
+    template <class T>
+    inline std::enable_if_t<!std::is_pointer<T>::value, std::add_lvalue_reference_t<T>>
+    closure_wrapper<CT>::deref(T& val) const
+    {
+        return val;
+    }
+
+    template <class CT>
+    template <class T, class CTA>
+    inline std::enable_if_t<std::is_pointer<T>::value, T>
+    closure_wrapper<CT>::get_storage_init(CTA&& e) const
+    {
+        return &e;
+    }
+
+    template <class CT>
+    template <class T, class CTA>
+    inline std::enable_if_t<!std::is_pointer<T>::value, T>
+    closure_wrapper<CT>::get_storage_init(CTA&& e) const
+    {
+        return e;
+    }
+
+    template <class CT>
+    inline bool closure_wrapper<CT>::equal(const self_type& rhs) const
+    {
+        return m_wrappee == rhs.m_wrappee;
+    }
+
+    template <class CT>
+    inline bool operator==(const closure_wrapper<CT>& lhs, const closure_wrapper<CT>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class CT>
+    inline bool operator!=(const closure_wrapper<CT>& lhs, const closure_wrapper<CT>& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    /*****************************
+     * closure and const_closure *
+     *****************************/
+
+    template <class T>
+    inline decltype(auto) closure(T&& t)
+    {
+        return closure_wrapper<closure_type_t<T>>(std::forward<T>(t));
+    }
+
+    template <class T>
+    inline decltype(auto) const_closure(T&& t)
+    {
+        return closure_wrapper<const_closure_type_t<T>>(std::forward<T>(t));
+    }
 }
 
 #endif

--- a/include/xtl/xcrtp.hpp
+++ b/include/xtl/xcrtp.hpp
@@ -1,0 +1,23 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_CRTP_HPP
+#define XTL_CRTP_HPP
+
+#include "xtl_config.hpp"
+
+namespace xtl
+{
+    template <class T>
+    auto derived_cast(T&& value)
+    {
+        return (std::forward<T>(value)).derived_cast();
+    }
+}
+
+#endif

--- a/include/xtl/xholder.hpp
+++ b/include/xtl/xholder.hpp
@@ -1,0 +1,251 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_HOLDER_HPP
+#define XTL_HOLDER_HPP
+
+#include "xcrtp.hpp"
+#include "xtl_config.hpp"
+
+namespace xtl
+{
+
+    template <class X>
+    struct xholder_inner_types;
+
+    template <class D>
+    class xholder_base
+    {
+    public:
+
+        using derived_type = D;
+
+        derived_type& derived_cast() & noexcept;
+        const derived_type& derived_cast() const & noexcept;
+        derived_type derived_cast() && noexcept;
+
+    protected:
+
+        xholder_base() = default;
+        ~xholder_base() = default;
+
+        xholder_base(const xholder_base&) = default;
+        xholder_base& operator=(const xholder_base&) = default;
+
+        xholder_base(xholder_base&&) = default;
+        xholder_base& operator=(xholder_base&&) = default;
+    };
+
+    template <template <class> class CRTP>
+    class xholder;
+
+    namespace detail
+    {
+        template <template <class> class CRTP>
+        class xholder_impl;
+    }
+
+    template <class CRTP>
+    struct xholder_inner_types<xholder<CRTP>>
+    {
+        using implementation_type = detail::xholder_impl<CRTP>;
+
+    };
+
+    template <template <class> class CRTP>
+    class xholder
+    {
+    public:
+
+        using self_type = xholder<CRTP>;
+        using implementation_type = typename xholder_inner_type<self_type>::implementation_type;
+
+
+        xholder();
+        ~xholder();
+        xholder(const xholder& rhs);
+        xholder(xholder&& rhs);
+        template <class D>
+        xholder(const CRTP<D>& rhs);
+        template <class D>
+        xholder(CRTP<D>&& rhs);
+        xholder(implementation_type* holder);
+
+        xholder& operator=(const xholder& rhs);
+        xholder& operator=(xholder&& rhs);
+
+        template <class D>
+        xholder& operator=(const CRTP<D>& rhs);
+        template <class D>
+        xholder& operator=(CRTP<D>&& rhs);
+
+        void swap(xholder& rhs);
+
+        //void display() const;
+        //xeus::xguid id() const;
+
+        template <class D>
+        D& get() &;
+        template <class D>
+        const D& get() const &;
+
+    private:
+
+        implementation_type* p_holder;
+    };
+
+    template <template <class> class CRTP>
+    inline void swap(xholder<CRTP>& lhs, xholder<CRTP>& rhs)
+    {
+        lhs.swap(rhs);
+    }
+
+    namespace detail
+    {
+        template <template <class> class CRTP>
+        class xholder_impl
+        {
+        public:
+      
+            xholder_impl() = default;
+            xholder_impl(xholder_impl&&) = delete;
+            xholder_impl& operator=(const xholder_impl&) = delete;
+            xholder_impl& operator=(xholder_impl&&) = delete;
+            virtual xholder_impl* clone() const = 0;
+            virtual ~xholder_impl() = default;
+            virtual bool owning() const = 0;
+
+        protected:
+
+            xholder_impl(const xholder_impl&) = default;
+        };
+
+        template <template <class> class CRTP, class D>
+        class xholder_owning : public xholder_impl<CRTP>
+        {
+        public:
+        
+            using base_type = xholder_impl<CRTP>;
+
+            xholder_owning(const CRTP<D>& value)
+                : base_type(),
+                  m_value(derived_cast(value))
+            {
+            }
+
+            xholder_owning(CRTP<D>&& value)
+                : base_type(),
+                  m_value(derived_cast(std::move(value)))
+            {
+            }
+
+            virtual ~xholder_owning()
+            {
+            }
+
+            virtual base_type* clone() const override
+            {
+                return new xholder_owning(*this);
+            }
+
+            inline D& value() & noexcept { return m_value; }
+            inline const D& value() const & noexcept { return m_value; }
+            inline D value() && noexcept { return m_value; }
+
+            virtual bool owning() const override
+            {
+                return true;
+            }
+
+        private:
+
+            xholder_owning(const xholder_owning&) = default;
+            D m_value;
+        };
+    }
+
+    template <template <class> class CRTP>
+    xholder<CRTP>::xholder()
+        : p_holder(nullptr)
+    {
+    }
+
+    template <template <class> class CRTP>
+    xholder<CRTP>::xholder(detail::xholder_impl<CRTP>* holder)
+        : p_holder(holder)
+    {
+    }
+
+    template <template <class> class CRTP>
+    xholder<CRTP>::~xholder()
+    {
+        delete p_holder;
+    }
+
+    template <template <class> class CRTP>
+    xholder<CRTP>::xholder(const xholder& rhs)
+        : p_holder(rhs.p_holder ? rhs.p_holder->clone() : nullptr)
+    {
+    }
+
+    template <template <class> class CRTP>
+    template <class D>
+    xholder<CRTP>::xholder(CRTP<D>&& rhs)
+        : xholder(make_owning_holder(std::move(rhs)))
+    {
+    }
+
+    template <template <class> class CRTP>
+    xholder<CRTP>::xholder(xholder&& rhs)
+        : p_holder(rhs.p_holder)
+    {
+        rhs.p_holder = nullptr;
+    }
+
+    template <template <class> class CRTP>
+    xholder<CRTP>& xholder<CRTP>::operator=(const xholder& rhs)
+    {
+        using std::swap;
+        xholder tmp(rhs);
+        swap(*this, tmp);
+        return *this;
+    }
+
+    template <template <class> class CRTP>
+    xholder<CRTP>& xholder<CRTP>::operator=(xholder&& rhs)
+    {
+        using std::swap;
+        xholder tmp(std::move(rhs));
+        swap(*this, tmp);
+        return *this;
+    }
+
+    template <template <class> class CRTP>
+    template <class D>
+    xholder<CRTP>& xholder<CRTP>::operator=(CRTP<D>&& rhs)
+    {
+        using std::swap;
+        xholder<CRTP> tmp(make_owning_holder(std::move(rhs)));
+        swap(tmp, *this);
+        return *this;
+    }
+
+    template <template <class> class CRTP>
+    void xholder<CRTP>::swap(xholder& rhs)
+    {
+        std::swap(p_holder, rhs.p_holder);
+    }
+
+    template <template <class> class CRTP, class D>
+    xholder<CRTP> make_owning_holder(const CRTP<D>& value)
+    {
+        return xholder<CRTP>(new detail::xholder_owning<CRTP, D>(value));
+    }
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ set(XTL_TESTS
     main.cpp
     test_xbasic_fixed_string.cpp
     test_xcomplex.cpp
+    test_xclosure.cpp
     test_xhash.cpp
     test_xoptional.cpp
 )

--- a/test/test_xclosure.cpp
+++ b/test/test_xclosure.cpp
@@ -1,0 +1,44 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+
+#include <type_traits>
+
+#include "xtl/xclosure.hpp"
+
+namespace xtl
+{
+    TEST(xclosure, closure_types)
+    {
+        bool rvalue_test = std::is_same<closure_type_t<double&&>, double>::value;
+        bool lvalue_reference_test = std::is_same<closure_type_t<double&>, double&>::value;
+        bool const_lvalue_reference_test = std::is_same<closure_type_t<const double&>, const double&>::value;
+
+        EXPECT_TRUE(rvalue_test);
+        EXPECT_TRUE(lvalue_reference_test);
+        EXPECT_TRUE(const_lvalue_reference_test);
+    }
+
+    TEST(xclosure, lvalue_closure_wrappers)
+    {
+        double x = 0.0;
+        auto x_closure = closure(x);
+        x_closure = 1.0;
+        EXPECT_EQ(x, 1.0);
+    }
+
+    TEST(xclosure, rvalue_closure_wrappers)
+    {
+        double x = 0.0;
+        auto x_closure = closure(std::move(x));
+        x_closure = 1.0;
+        EXPECT_EQ(x, 0.0);
+    }
+}
+

--- a/test/test_xcomplex.cpp
+++ b/test/test_xcomplex.cpp
@@ -16,7 +16,7 @@ namespace xtl
 {
     using namespace std::complex_literals;
 
-    TEST(utils, forward_offset)
+    TEST(xcomplex, forward_offset)
     {
         // Test that lvalues can be modified
         std::complex<double> clv;


### PR DESCRIPTION
Should we 

- remove `const_ptr_closure_type` 
- move `ptr_closure_type` to `detail` in next backward incompat version?