### PR TITLE
Use releash for release management

### DIFF
--- a/.releash.py
+++ b/.releash.py
@@ -1,0 +1,17 @@
+from releash import *
+
+gitpush = ReleaseTargetGitPush('upstream', 'master')
+
+xtl = add_package(path=".", name="xtl")
+version_xtl = VersionSourceAndTargetHpp(xtl, '{path}/include/xtl/xtl_config.hpp', prefix='XTL_VERSION_')
+gittag_xtl = ReleaseTargetGitTagVersion(version_source=version_xtl, prefix='', annotate=True)
+
+xtl.version_source = version_xtl
+xtl.version_targets.append(version_xtl)
+
+xtl.release_targets.append(gittag_xtl)
+xtl.release_targets.append(gitpush)
+
+source_tarball_filename = 'https://github.com/QuantStack/xtl/archive/{version}.tar.gz'.format(version=version_xtl)
+xtl.release_targets.append(ReleaseTargetCondaForge(xtl, '../xtl-feedstock', source_tarball_filename=source_tarball_filename))
+


### PR DESCRIPTION
To install:
```bash
pip install releash
```

Workflow:
```bash
$ releash status
# see status, should be all green
# make changes, commit
$ releash status
# will hint to bump version number
$ releash bump --what=patch
# this will bump the version number, and commit the changes
$ releash release
# will tag (annotated), push changes, download the tarball
# and update the recipe in ../xtl-feedstock
```
