### PR TITLE
No warnings on VC14 (win32 and x64)

### DIFF
--- a/include/xtl/xhash.hpp
+++ b/include/xtl/xhash.hpp
@@ -129,7 +129,7 @@ namespace xtl
         }
 #elif INTPTR_MAX == INT32_MAX
         //64-bits hash for 32-bits platform
-        inline void mmix(uint32_t& h, uint32_t& k, const uint32_t m, const int r)
+        inline void mmix(uint32_t& h, uint32_t& k, uint32_t m, int r)
         {
             k *= m; k ^= k >> r; k *= m; h *= m; h ^= k;
         }
@@ -141,7 +141,7 @@ namespace xtl
             const int r = 24;
             uint32_t l = length;
 
-            const unsigned char * data = (const unsigned char *)buffer;
+            const auto* data = reinterpret_cast<const unsigned char*>(buffer);
 
             uint32_t h = seed;
 

--- a/include/xtl/xhash.hpp
+++ b/include/xtl/xhash.hpp
@@ -129,69 +129,45 @@ namespace xtl
         }
 #elif INTPTR_MAX == INT32_MAX
         //64-bits hash for 32-bits platform
+#define mmix(h,k) { k *= m; k ^= k >> r; k *= m; h *= m; h ^= k; }
+
         template <>
         inline std::size_t murmur_hash<8>(const void* buffer, std::size_t length, std::size_t seed)
         {
-            constexpr uint32_t m = 0x5bd1e995;
-            constexpr int r = 24;
+            const uint32_t m = 0x5bd1e995;
+            const int r = 24;
+            uint32_t l = length;
 
-            uint32_t h1 = uint32_t(seed) ^ int(length);
-            uint32_t h2 = uint32_t(seed >> 32);
+            const unsigned char * data = (const unsigned char *)buffer;
 
-            const uint32_t* data = static_cast<const uint32_t*>(buffer);
+            uint32_t h = seed;
 
-            while (length >= 8)
+            while (length >= 4)
             {
-                uint32_t k1 = *data++;
-                k1 *= m;
-                k1 ^= k1 >> r;
-                k1 *= m;
-                h1 *= m;
-                h1 ^= k1;
-                length -= 4;
+                uint32_t k = *(uint32_t*)data;
 
-                uint32_t k2 = *data++;
-                k2 *= m;
-                k2 ^= k2 >> r;
-                k2 *= m;
-                h2 *= m;
-                h2 ^= k2;
+                mmix(h, k);
+
+                data += 4;
                 length -= 4;
             }
 
-            if (length >= 4)
-            {
-                uint32_t k1 = *data++;
-                k1 *= m;
-                k1 ^= k1 >> r;
-                k1 *= m;
-                h1 *= m;
-                h1 ^= k1;
-                length -= 4;
-            }
+            uint32_t t = 0;
 
             switch (length)
             {
-            case 3:
-                h2 ^= ((unsigned char*)data)[2] << 16;
-            case 2:
-                h2 ^= ((unsigned char*)data)[1] << 8;
-            case 1:
-                h2 ^= ((unsigned char*)data)[0];
-                h2 *= m;
-            }
+            case 3: t ^= data[2] << 16;
+            case 2: t ^= data[1] << 8;
+            case 1: t ^= data[0];
+            };
 
-            h1 ^= h2 >> 18;
-            h1 *= m;
-            h2 ^= h1 >> 22;
-            h2 *= m;
-            h1 ^= h2 >> 17;
-            h1 *= m;
-            h2 ^= h1 >> 19;
-            h2 *= m;
+            mmix(h, t);
+            mmix(h, l);
 
-            uint64_t h = h1;
-            h = (h << 32) | h2;
+            h ^= h >> 13;
+            h *= m;
+            h ^= h >> 15;
+
             return h;
         }
 #else

--- a/include/xtl/xhash.hpp
+++ b/include/xtl/xhash.hpp
@@ -129,7 +129,10 @@ namespace xtl
         }
 #elif INTPTR_MAX == INT32_MAX
         //64-bits hash for 32-bits platform
-#define mmix(h,k) { k *= m; k ^= k >> r; k *= m; h *= m; h ^= k; }
+        inline void mmix(uint32_t& h, uint32_t& k, const uint32_t m, const int r)
+        {
+            k *= m; k ^= k >> r; k *= m; h *= m; h ^= k;
+        }
 
         template <>
         inline std::size_t murmur_hash<8>(const void* buffer, std::size_t length, std::size_t seed)
@@ -146,7 +149,7 @@ namespace xtl
             {
                 uint32_t k = *(uint32_t*)data;
 
-                mmix(h, k);
+                mmix(h, k, m, r);
 
                 data += 4;
                 length -= 4;
@@ -161,8 +164,8 @@ namespace xtl
             case 1: t ^= data[0];
             };
 
-            mmix(h, t);
-            mmix(h, l);
+            mmix(h, t, m, r);
+            mmix(h, l, m, r);
 
             h ^= h >> 13;
             h *= m;

--- a/include/xtl/xvariant_impl.hpp
+++ b/include/xtl/xvariant_impl.hpp
@@ -1257,7 +1257,7 @@ namespace mpark {
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4244)
+#pragma warning(disable : 4244 4800 )
 #endif
             template <typename... Args>
             inline explicit constexpr alt(in_place_t, Args &&... args)


### PR DESCRIPTION
Silenced C4800 level 3 which shows up with VS2015 sp3 for x64 builds.

The murmur hash implementation for win32 is wrong. The one for uint32_t should have been picked. The code that was picked is actually the one for 64bit hash on a 32bit platform. In fact detail::murmur_hash uses size_t which is always the same size as int* and therefore 32bit when INTPTR_MAX == INT32_MAX.