### PR TITLE
Move xtl::xoptional JSON serialization to xtl

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda install gtest cmake -c conda-forge
+  - conda install gtest cmake nlohmann_json -c QuantStack -c conda-forge
   - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON .
   - nmake test_xtl
   - cd test

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
-    - conda install gtest cmake -c conda-forge 
+    - conda install gtest cmake nlohmann_json -c QuantStack -c conda-forge
     # Testing
     - mkdir build
     - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,14 @@ foreach(ver ${xtl_version_defines})
         set(XTL_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
     endif()
 endforeach()
-set(${PROJECT_NAME}_VERSION 
+set(${PROJECT_NAME}_VERSION
     ${XTL_VERSION_MAJOR}.${XTL_VERSION_MINOR}.${XTL_VERSION_PATCH})
 message(STATUS "xtl v${${PROJECT_NAME}_VERSION}")
 
+# Dependencies
+# ============
+
+find_package(nlohmann_json)
 
 # Build
 # =====
@@ -40,6 +44,7 @@ set(XTL_HEADERS
     ${XTL_INCLUDE_DIR}/xtl/xhash.hpp
     ${XTL_INCLUDE_DIR}/xtl/xhierarchy_generator.hpp
     ${XTL_INCLUDE_DIR}/xtl/xiterator_base.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xjson.hpp
     ${XTL_INCLUDE_DIR}/xtl/xmeta_utils.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional_sequence.hpp

--- a/include/xtl/xany.hpp
+++ b/include/xtl/xany.hpp
@@ -1,3 +1,11 @@
+/***************************************************************************
+* Copyright (c) 2016, Sylvain Corlay and Johan Mabille                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
 #ifndef XTL_ANY_HPP
 #define XTL_ANY_HPP
 

--- a/include/xtl/xjson.hpp
+++ b/include/xtl/xjson.hpp
@@ -1,0 +1,40 @@
+#ifndef XTL_JSON_HPP
+#define XTL_JSON_HPP
+
+#include "nlohmann/json.hpp"
+#include "xoptional.hpp"
+
+namespace xtl
+{
+    /***********************************************************
+     * to_json and from_json specialization for xtl::xoptional *
+     ***********************************************************/
+
+    template <class D>
+    void to_json(nlohmann::json& j, const xoptional<D>& o)
+    {
+        if (!o.has_value())
+        {
+            j = nullptr;
+        }
+        else
+        {
+            j = o.value();
+        }
+    }
+
+    template <class D>
+    void from_json(const nlohmann::json& j, xoptional<D>& o)
+    {
+        if (j.is_null())
+        {
+            o = missing<D>();
+        }
+        else
+        {
+            o = j.get<D>();
+        }
+    }
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,7 +98,7 @@ add_executable(${XTL_TARGET} ${XTL_TESTS} ${XTL_HEADERS})
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     add_dependencies(${XTL_TARGET} gtest_main)
 endif()
-target_link_libraries(${XTL_TARGET} xtl ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${XTL_TARGET} xtl nlohmann_json ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 add_custom_target(xtest COMMAND test_xtl DEPENDS ${XTL_TARGET})
 

--- a/test/test_xoptional.cpp
+++ b/test/test_xoptional.cpp
@@ -15,6 +15,7 @@
 
 #include "xtl/xany.hpp"
 #include "xtl/xoptional.hpp"
+#include "xtl/xjson.hpp"
 #include "xtl/xoptional_sequence.hpp"
 
 namespace xtl
@@ -113,7 +114,7 @@ namespace xtl
         EXPECT_TRUE(v1 > v2);
         EXPECT_FALSE(v2 > v1);
         EXPECT_TRUE(v1 >= v1);
-        EXPECT_FALSE(v2 >= v1);    
+        EXPECT_FALSE(v2 >= v1);
     }
 
     TEST(xoptional, io)
@@ -275,4 +276,15 @@ namespace xtl
         EXPECT_EQ(res.has_value(), o.has_value());
     }
 
+    TEST(xoptional, json)
+    {
+        xoptional<double> m1 = missing<double>();
+        nlohmann::json j1 = m1;
+        EXPECT_TRUE(j1.is_null());
+        EXPECT_EQ(j1.get<xoptional<double>>(), missing<double>());
+
+        xoptional<double> m2 = 3.0;
+        nlohmann::json j2 = m2;
+        EXPECT_EQ(j2.get<xoptional<double>>(), 3.0);
+    }
 }


### PR DESCRIPTION
This is a "backward compatible" change since the old version of xwidgets still does not import `xtl/xjson.hpp`.

In order for this header to make sense, nlohmann_json must be installed.

The proposal is to do the same with `xtensor`,  that is to create an `xtensor/xjson.hpp` file which includes `nlohmann/json.hpp`.

Another possibility is to forward-declare `nlohmann::json`.

@JohanMabille thoughts?