### PR TITLE
Add hash.verification result for big-endian systems.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,12 @@ endif()
 
 find_package(Threads)
 
+include(TestBigEndian)
+TEST_BIG_ENDIAN(BIG_ENDIAN)
+if(BIG_ENDIAN)
+    add_definitions(-DSYSTEM_IS_BIG_ENDIAN)
+endif(BIG_ENDIAN)
+
 include_directories(${GTEST_INCLUDE_DIRS})
 
 set(XTL_TESTS

--- a/test/test_xhash.cpp
+++ b/test/test_xhash.cpp
@@ -146,7 +146,11 @@ namespace xtl
     TEST(hash, verification)
     {
 #if INTPTR_MAX == INT64_MAX
+#if SYSTEM_IS_BIG_ENDIAN
+        uint32_t res = 0x8fda498d;
+#else
         uint32_t res = sizeof(std::size_t) == 4 ? 0x27864c1e : 0x1f0d3804;
+#endif
 #elif INTPTR_MAX == INT32_MAX
         uint32_t res = sizeof(std::size_t) == 4 ? 0x27864c1e : 0xdd537c05;
 #else


### PR DESCRIPTION
I assume for now that only 64-bit systems with sizeof(size_t) == 8 are relevant.

Fixes #72.