### PR TITLE
Made nlohmann_json optional in the tests, exported c++14 requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ add_library(xtl INTERFACE)
 target_include_directories(xtl INTERFACE $<BUILD_INTERFACE:${XTL_INCLUDE_DIR}>
                                          $<INSTALL_INTERFACE:include>)
 
+# xtl requires C++14 support!
+target_compile_features(xtl INTERFACE cxx_std_14)
+
 
 OPTION(BUILD_TESTS "xtl test suite" OFF)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtl-test)
 
     find_package(xtl REQUIRED CONFIG)
+    find_package(nlohmann_json QUIET CONFIG)
     set(XTL_INCLUDE_DIR ${xtl_INCLUDE_DIRS})
 endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,13 +30,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     if (HAS_MARCH_NATIVE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
     endif()
-
-    CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
-    if (HAS_CPP14_FLAG)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    else()
-        message(FATAL_ERROR "Unsupported compiler -- xtl requires C++14 support!")
-    endif()
 endif()
 
 if(MSVC)
@@ -98,11 +91,14 @@ set(XTL_TESTS
     test_xhierarchy_generator.cpp
     test_xiterator_base.cpp
     test_xmeta_utils.cpp
-    test_xoptional.cpp
     test_xtype_traits.cpp
     test_xproxy_wrapper.cpp
     test_xvariant.cpp
 )
+
+if(nlohmann_json_FOUND)
+  list(APPEND XTL_TESTS test_xoptional.cpp)
+endif()
 
 set(XTL_TARGET test_xtl)
 
@@ -110,7 +106,17 @@ add_executable(${XTL_TARGET} ${XTL_TESTS} ${XTL_HEADERS})
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     add_dependencies(${XTL_TARGET} gtest_main)
 endif()
-target_link_libraries(${XTL_TARGET} xtl nlohmann_json ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${XTL_TARGET} xtl ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+if(nlohmann_json_FOUND)
+  # Version up to 3.1.2 export the target `nlohmann_json`
+  if(TARGET nlohmann_json)
+    target_link_libraries(${XTL_TARGET} nlohmann_json)
+  # Newer versions export the namespaced target `nlohmann_json::nlohmann_json`
+  elseif(TARGET nlohmann_json::nlohmann_json)
+    target_link_libraries(${XTL_TARGET} nlohmann_json::nlohmann_json)
+  endif()
+endif()
 
 add_custom_target(xtest COMMAND test_xtl DEPENDS ${XTL_TARGET})
 


### PR DESCRIPTION
Prior to this PR `xtl` did not properly export it's compile feature requirement `cxx_std_14`. This now propagates to other targets that link against `xtl`.

When building from `test`and not the root `xtl` directory cmake now properly tries to find the `nlohmann_json` package. In addition if it fails to find `nlohmann_json` it will not compile `test_xoptional.cpp` and not link against `nlohmann_json`.
Furthermore `nlohmann_json` recently adapt to the more modern namespaced targets https://github.com/nlohmann/json/pull/1048 currently only on master branch. The new `CMakeLists.txt` will use the correct target i.e. `nlohmann_json` or `nlohmann_json::nlohmann_json`.

This also should fix #101 .