### PR TITLE
switch to trusty and add recent clang compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: precise
+dist: trusty
 matrix:
   include:
     - os: linux
@@ -31,8 +31,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
           packages:
+            - g++-4.9
             - clang-3.6
       env: COMPILER=clang CLANG=3.6
     - os: linux
@@ -40,17 +40,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
           packages:
-            - clang-3.7
-      env: COMPILER=clang CLANG=3.7
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-          packages:
+            - g++-4.9
             - clang-3.8
       env: COMPILER=clang CLANG=3.8
     - os: linux
@@ -58,10 +49,39 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
           packages:
+            - g++-4.9
             - clang-3.9
       env: COMPILER=clang CLANG=3.9
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - g++-4.9
+            - clang-4.0
+      env: COMPILER=clang CLANG=4.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - g++-4.9
+            - clang-5.0
+      env: COMPILER=clang CLANG=5.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+      env: COMPILER=clang CLANG=6.0
     - os: osx
       osx_image: xcode8
       compiler: clang


### PR DESCRIPTION
See [here](https://github.com/QuantStack/xtensor/pull/384) for an explanation about the installation of gcc 4.9 with clang. Notice that installing clang-6.0 triggers the installation of a recent version of gcc, so installing gcc 4.9 is not required for this one.

- `clang-3.6/3.8/3.9` do not require `llvm-toolchain-trusty-3.6/3.8/3.9` and work fine
- `clang-3.7` apparently still requires `llvm-toolchain-trusty-3.7`, which is not available in [apt source safelist](https://github.com/travis-ci/apt-source-safelist/blob/master/ubuntu.json#L191).
- `clang-4.0/5.0/6.0` require `llvm-toolchain-trusty-4.0/5.0/6.0` which are available in [apt source safelist](https://github.com/travis-ci/apt-source-safelist/blob/master/ubuntu.json#L191).

Thus `clang-3.7` is removed from the ci, this is not a big deal since we keep `clang-3.6`. An issue will be opened to keep support for `clang-3.9` only.