### PR TITLE
fix forward_sequence behavior for non resizable types (std::array et al)

### DIFF
--- a/include/xtl/xmeta_utils.hpp
+++ b/include/xtl/xmeta_utils.hpp
@@ -16,6 +16,19 @@
 
 namespace xtl
 {
+    // TODO move to a xutils if we have one
+
+    // gcc 4.9 is affected by C++14 defect CGW 1558
+    // see http://open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#1558
+    template <class... T>
+    struct make_void
+    {
+        using type = void;
+    };
+
+    template <class... T>
+    using void_t = typename make_void<T...>::type;
+
     namespace mpl
     {
         /*************

--- a/test/test_xsequence.cpp
+++ b/test/test_xsequence.cpp
@@ -15,12 +15,18 @@
 
 namespace xtl
 {
-    bool result(const std::array<int, 2>& lval)
+    template <class T, std::size_t N>
+    struct aligned_array
+        : std::array<T, N>
+    {
+    };
+
+    bool result(const std::array<int, 2>& /*lval*/)
     {
         return false;
     }
 
-    bool result(std::array<int, 2>&& lval)
+    bool result(std::array<int, 2>&& /*lval*/)
     {
         return true;
     }
@@ -52,6 +58,21 @@ namespace xtl
         EXPECT_FALSE(test_wrong(a));
         EXPECT_TRUE(test_wrong(c));
         EXPECT_TRUE(test_wrong(std::move(c)));
+    }
+
+    template <class R, class T>
+    R test_different_array(T& array)
+    {
+        return xtl::forward_sequence<R, T>(array);
+    }
+
+    TEST(xsequence, different_arrays)
+    {
+        std::array<int, 3> x, y;
+        aligned_array<int, 3> aa, ab;
+
+        auto res1 = test_different_array<aligned_array<int, 3>>(x);
+        auto res2 = test_different_array<aligned_array<int, 3>>(aa);
     }
 }
 


### PR DESCRIPTION
@tdegeus this will fix the issue you were experiencing with the noalias assign of xadapt.