### PR TITLE
Add missing entries of header files in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ set(XTL_HEADERS
     ${XTL_INCLUDE_DIR}/xtl/xclosure.hpp
     ${XTL_INCLUDE_DIR}/xtl/xcomplex.hpp
     ${XTL_INCLUDE_DIR}/xtl/xcomplex_sequence.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xspan.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xspan_impl.hpp
     ${XTL_INCLUDE_DIR}/xtl/xdynamic_bitset.hpp
     ${XTL_INCLUDE_DIR}/xtl/xfunctional.hpp
     ${XTL_INCLUDE_DIR}/xtl/xhash.hpp


### PR DESCRIPTION
Two new header files were added in https://github.com/QuantStack/xtl/commit/afa84bdde2d6880dc542b39f2870bf452549e1ff, but `CMakeLists.txt` didn't get updated.