### PR TITLE
closure wrapper assignment fixed

### DIFF
--- a/include/xtl/xclosure.hpp
+++ b/include/xtl/xclosure.hpp
@@ -118,6 +118,12 @@ namespace xtl
         xclosure_wrapper(value_type&& e);
         xclosure_wrapper(reference e);
 
+        xclosure_wrapper(const self_type& rhs) = default;
+        xclosure_wrapper(self_type&& rhs) = default;
+
+        self_type& operator=(const self_type& rhs);
+        self_type& operator=(self_type&& rhs);
+        
         template <class T>
         self_type& operator=(T&&);
 
@@ -131,6 +137,7 @@ namespace xtl
         pointer operator&() noexcept;
 
         bool equal(const self_type& rhs) const;
+        void swap(self_type& rhs);
 
     private:
 
@@ -221,9 +228,22 @@ namespace xtl
     }
 
     template <class CT>
+    inline auto xclosure_wrapper<CT>::operator=(const self_type& rhs) -> self_type&
+    {
+        deref(m_wrappee) = deref(rhs.m_wrappee);
+        return *this;
+    }
+
+    template <class CT>
+    inline auto xclosure_wrapper<CT>::operator=(self_type&& rhs) -> self_type&
+    {
+        swap(rhs);
+        return *this;
+    }
+
+    template <class CT>
     template <class T>
-    inline auto xclosure_wrapper<CT>::operator=(T&& t)
-        -> self_type&
+    inline auto xclosure_wrapper<CT>::operator=(T&& t) -> self_type&
     {
         deref(m_wrappee) = std::forward<T>(t);
         return *this;
@@ -320,6 +340,13 @@ namespace xtl
     }
 
     template <class CT>
+    inline void xclosure_wrapper<CT>::swap(self_type& rhs)
+    {
+        using std::swap;
+        swap(deref(m_wrappee), deref(rhs.m_wrappee));
+    }
+
+    template <class CT>
     inline bool operator==(const xclosure_wrapper<CT>& lhs, const xclosure_wrapper<CT>& rhs)
     {
         return lhs.equal(rhs);
@@ -329,6 +356,12 @@ namespace xtl
     inline bool operator!=(const xclosure_wrapper<CT>& lhs, const xclosure_wrapper<CT>& rhs)
     {
         return !(lhs == rhs);
+    }
+
+    template <class CT>
+    inline void swap(xclosure_wrapper<CT>& lhs, xclosure_wrapper<CT>& rhs)
+    {
+        lhs.swap(rhs);
     }
 
     /***********************************

--- a/test/test_xbasic_fixed_string.cpp
+++ b/test/test_xbasic_fixed_string.cpp
@@ -9,7 +9,10 @@
 #include "gtest/gtest.h"
 
 #include "xtl/xbasic_fixed_string.hpp"
+
+#ifdef HAVE_NLOHMANN_JSON
 #include "xtl/xjson.hpp"
+#endif
 
 namespace xtl
 {

--- a/test/test_xclosure.cpp
+++ b/test/test_xclosure.cpp
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 
 #include <type_traits>
+#include <vector>
 
 #include "xtl/xclosure.hpp"
 
@@ -41,6 +42,99 @@ namespace xtl
         x_closure = 1.0;
         EXPECT_EQ(x, 0.0);
         EXPECT_NE(&x, &x_closure);
+    }
+
+    TEST(xclosure, copy)
+    {
+        std::vector<int> v = { 1, 2, 3 };
+        auto cl1 = closure(v);
+        auto cl2(cl1);
+
+        cl2.get()[0] = 4;
+        EXPECT_EQ(v[0], 4);
+
+        auto cl3(const_cast<const std::decay_t<decltype(cl1)>&>(cl1));
+        cl3.get()[0] = 5;
+        EXPECT_EQ(v[0], 5);
+    }
+
+    TEST(xclosure, assign)
+    {
+        std::vector<int> v1 = { 1, 2, 3 };
+        std::vector<int> v2 = { 3, 2, 1 };
+        std::vector<int> v3 = v1;
+
+        auto cl1 = closure(v1);
+        auto cl2 = closure(v2);
+        auto cl3 = closure(v3);
+
+        cl1 = cl2;
+        EXPECT_EQ(v1, v2);
+
+        cl3 = const_cast<const std::decay_t<decltype(cl2)>&>(cl2);
+        EXPECT_EQ(v3, v2);
+    }
+
+    TEST(xclosure, move)
+    {
+        std::vector<int> v = { 1, 2, 3 };
+
+        auto cl1 = closure(v);
+        auto cl2(std::move(cl1));
+
+        cl2.get()[0] = 4;
+        EXPECT_EQ(v[0], 4);
+    }
+
+    TEST(xclosure, move_assign)
+    {
+        std::vector<int> v1 = { 1, 2, 3 };
+        std::vector<int> v2 = { 3, 2, 1 };
+        std::vector<int> v3 = v2;
+
+        auto cl1 = closure(v1);
+        auto cl2 = closure(v2);
+
+        cl1 = std::move(cl2);
+        EXPECT_EQ(v1, v3);
+        
+    }
+
+    TEST(xclosure, swap)
+    {
+        std::vector<int> v1 = { 1, 2, 3 };
+        std::vector<int> v2 = { 3, 2, 1 };
+        std::vector<int> v3 = v1;
+        std::vector<int> v4 = v2;
+
+        auto cl1 = closure(v1);
+        auto cl2 = closure(v2);
+
+        using std::swap;
+        swap(cl1, cl2);
+        EXPECT_EQ(v1, v4);
+        EXPECT_EQ(v2, v3);
+    }
+
+    TEST(xclosure, swap_pointers)
+    {
+        int* d1 = new int[3];
+        int* d2 = new int[3];
+
+        int* d3 = d1;
+        int* d4 = d2;
+
+        auto cl1 = closure(d1);
+        auto cl2 = closure(d2);
+
+        using std::swap;
+        swap(cl1, cl2);
+
+        EXPECT_EQ(d1, d4);
+        EXPECT_EQ(d2, d3);
+
+        delete[] d2;
+        delete[] d1;
     }
 
     TEST(xclosure_pointer, lvalue_closure_wrappers)


### PR DESCRIPTION
After this is merged and release, `xbuffer_owner_storage.move_assign` test needs to be fixed in xtensor.