### PR TITLE
Implementation of concept

### DIFF
--- a/include/xtl/xtype_traits.hpp
+++ b/include/xtl/xtype_traits.hpp
@@ -129,13 +129,23 @@ namespace xtl
     };
 
     /******************
-     * negation - and *
+     * negation - not *
      ******************/
 
     template <class Arg>
     struct negation : std::integral_constant<bool, !Arg::value>
     {
     };
+
+    /************
+     * concepts *
+     ************/
+
+    template <class... C>
+    using check_concept = std::enable_if_t<conjunction<C...>::value, int>;
+
+#define XTL_REQUIRES(...) check_concept<__VA_ARGS__> = 0
+
 }
 
 #endif

--- a/test/test_xtype_traits.cpp
+++ b/test/test_xtype_traits.cpp
@@ -54,5 +54,33 @@ namespace xtl
         res = disjunction<false_type, false_type, false_type>::value;
         EXPECT_EQ(res, false);
     }
+
+    template <class T, XTL_REQUIRES(std::is_integral<T>, std::is_signed<T>)>
+    int test_concept(T)
+    {
+        return 0;
+    }
+
+    template <class T, XTL_REQUIRES(std::is_integral<T>, xtl::negation<std::is_signed<T>>)>
+    int test_concept(T)
+    {
+        return 1;
+    }
+
+    template <class T, XTL_REQUIRES(xtl::negation<std::is_integral<T>>)>
+    int test_concept(T)
+    {
+        return 2;
+    }
+
+    TEST(xtype_traits, concepts)
+    {
+        int i = 0;
+        unsigned int ui = 1u;
+        double d = 1.;
+        EXPECT_EQ(test_concept(i), 0);
+        EXPECT_EQ(test_concept(ui), 1);
+        EXPECT_EQ(test_concept(d), 2);
+    }
 }
 


### PR DESCRIPTION
This PR allows to use SFINAE in functions in a readable way (more than raw `std::enable_if_t`):

```cpp
template <class T, XTL_REQUIRES(std::is_integral<T>, std::is_signed<T>)>
void do_something(T) { ... }

template <class T, XTL_REQUIRES(std::is_integral<T>, xtl::negation<std::is_signed<T>>)>
void do_something(T) { ... }

template <class T, XTL_REQUIRES(xtl::negation<std::is_integral<T>>)>
void do_something(T) { ... }
```
