### PR TITLE
Fixed travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,11 +108,11 @@ install:
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
-    - conda install gtest cmake nlohmann_json -c QuantStack -c conda-forge
+    - conda install cmake nlohmann_json -c QuantStack -c conda-forge
     # Testing
     - mkdir build
     - cd build
-    - cmake -DBUILD_TESTS=ON ..;
+    - cmake -DDOWNLOAD_GTEST=ON ..;
     - make -j2 test_xtl
     - cd test
 script:


### PR DESCRIPTION
Now that gtest is built with gcc-7 on conda-forge, we cannot link with it anymore, we have to build it with the local compiler.