### PR TITLE
Move xmasked_value from xtensor to xtl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,10 @@ set(XTL_HEADERS
     ${XTL_INCLUDE_DIR}/xtl/xhierarchy_generator.hpp
     ${XTL_INCLUDE_DIR}/xtl/xiterator_base.hpp
     ${XTL_INCLUDE_DIR}/xtl/xjson.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xmasked_value_meta.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xmasked_value.hpp
     ${XTL_INCLUDE_DIR}/xtl/xmeta_utils.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xoptional_meta.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional_sequence.hpp
     ${XTL_INCLUDE_DIR}/xtl/xproxy_wrapper.hpp

--- a/include/xtl/xmasked_value.hpp
+++ b/include/xtl/xmasked_value.hpp
@@ -1,0 +1,543 @@
+/***************************************************************************
+* Copyright (c) 2017, Johan Mabille, Sylvain Corlay, Wolf Vollprecht and   *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_XMASKED_VALUE_HPP
+#define XTL_XMASKED_VALUE_HPP
+
+#include "xmasked_value_meta.hpp"
+#include "xtype_traits.hpp"
+
+namespace xtl
+{
+    template <class T>
+    inline xmasked_value<T, bool> masked() noexcept
+    {
+        return xmasked_value<T, bool>(T(0), false);
+    }
+
+    /****************************
+    * xmasked_value declaration *
+    *****************************/
+
+    template <class T, class B>
+    class xmasked_value
+    {
+    public:
+
+        using self_type = xmasked_value<T, B>;
+
+        using value_type = T;
+        using flag_type = B;
+
+        template <class T1, class B1>
+        constexpr xmasked_value(T1&& value, B1&& flag);
+
+        template <class T1>
+        constexpr xmasked_value(T1&& value);
+
+        explicit constexpr xmasked_value();
+
+        inline operator value_type() {
+            return m_value;
+        }
+
+        std::add_lvalue_reference_t<T> value() & noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<T>> value() const & noexcept;
+        std::conditional_t<std::is_reference<T>::value, apply_cv_t<T, std::decay_t<T>>&, std::decay_t<T>> value() && noexcept;
+        std::conditional_t<std::is_reference<T>::value, const std::decay_t<T>&, std::decay_t<T>> value() const && noexcept;
+
+        std::add_lvalue_reference_t<B> visible() & noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<B>> visible() const & noexcept;
+        std::conditional_t<std::is_reference<B>::value, apply_cv_t<B, std::decay_t<B>>&, std::decay_t<B>> visible() && noexcept;
+        std::conditional_t<std::is_reference<B>::value, const std::decay_t<B>&, std::decay_t<B>> visible() const && noexcept;
+
+        template <class T1, class B1>
+        bool equal(const xmasked_value<T1, B1>& rhs) const noexcept;
+
+        template <class T1, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>
+        bool equal(const T1& rhs) const noexcept;
+
+        template <class T1, class B1>
+        void swap(xmasked_value<T1, B1>& other);
+
+#define DEFINE_ASSIGN_OPERATOR(OP)                                                            \
+        template <class T1>                                                                   \
+        inline xmasked_value& operator OP(const T1& rhs)                                      \
+        {                                                                                     \
+            if (m_visible)                                                                    \
+            {                                                                                 \
+                m_value OP rhs;                                                               \
+            }                                                                                 \
+            return *this;                                                                     \
+        }                                                                                     \
+                                                                                              \
+        template <class T1, class B1>                                                         \
+        inline xmasked_value& operator OP(const xmasked_value<T1, B1>& rhs)                   \
+        {                                                                                     \
+            m_visible = m_visible && rhs.visible();                                           \
+            if (m_visible)                                                                    \
+            {                                                                                 \
+                m_value OP rhs.value();                                                       \
+            }                                                                                 \
+            return *this;                                                                     \
+        }
+
+        DEFINE_ASSIGN_OPERATOR(=);
+        DEFINE_ASSIGN_OPERATOR(+=);
+        DEFINE_ASSIGN_OPERATOR(-=);
+        DEFINE_ASSIGN_OPERATOR(*=);
+        DEFINE_ASSIGN_OPERATOR(/=);
+        DEFINE_ASSIGN_OPERATOR(%=);
+        DEFINE_ASSIGN_OPERATOR(&=);
+        DEFINE_ASSIGN_OPERATOR(|=);
+        DEFINE_ASSIGN_OPERATOR(^=);
+#undef DEFINE_ASSIGN_OPERATOR
+
+    private:
+
+        value_type m_value;
+        flag_type m_visible;
+    };
+
+    /********************************
+     * xmasked_value implementation *
+     ********************************/
+
+    template <class T, class B>
+    template <class T1, class B1>
+    inline constexpr xmasked_value<T, B>::xmasked_value(T1&& value, B1&& flag)
+        : m_value(std::forward<T1>(value)), m_visible(std::forward<B1>(flag))
+    {
+    }
+
+    template <class T, class B>
+    template <class T1>
+    inline constexpr xmasked_value<T, B>::xmasked_value(T1&& value)
+        : m_value(std::forward<T1>(value)), m_visible(true)
+    {
+    }
+
+    template <class T, class B>
+    inline constexpr xmasked_value<T, B>::xmasked_value()
+        : m_value(0), m_visible(true)
+    {
+    }
+
+    template <class T>
+    inline auto masked_value(T&& val)
+    {
+        return xmasked_value<T>(std::forward<T>(val));
+    }
+
+    template <class T, class B>
+    inline auto masked_value(T&& val, B&& mask)
+    {
+        return xmasked_value<T, B>(std::forward<T>(val), std::forward<B>(mask));
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() & noexcept -> std::add_lvalue_reference_t<T>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() const & noexcept -> std::add_lvalue_reference_t<std::add_const_t<T>>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() && noexcept -> std::conditional_t<std::is_reference<T>::value, apply_cv_t<T, std::decay_t<T>>&, std::decay_t<T>>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() const && noexcept -> std::conditional_t<std::is_reference<T>::value, const std::decay_t<T>&, std::decay_t<T>>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() & noexcept -> std::add_lvalue_reference_t<B>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() const & noexcept -> std::add_lvalue_reference_t<std::add_const_t<B>>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() && noexcept -> std::conditional_t<std::is_reference<B>::value, apply_cv_t<B, std::decay_t<B>>&, std::decay_t<B>>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() const && noexcept -> std::conditional_t<std::is_reference<B>::value, const std::decay_t<B>&, std::decay_t<B>>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    template <class T1, class B1>
+    inline bool xmasked_value<T, B>::equal(const xmasked_value<T1, B1>& rhs) const noexcept
+    {
+        return (!m_visible && !rhs.visible()) || (m_value == rhs.value() && (m_visible && rhs.visible()));
+    }
+
+    template <class T, class B>
+    template <class T1, check_concept<negation<is_xmasked_value<T1>>>>
+    inline bool xmasked_value<T, B>::equal(const T1& rhs) const noexcept
+    {
+        return m_visible && m_value == rhs;
+    }
+
+    template <class T, class B>
+    template <class T1, class B1>
+    inline void xmasked_value<T, B>::swap(xmasked_value<T1, B1>& other)
+    {
+        using std::swap;
+        swap(m_value, other.m_value);
+        swap(m_visible, other.m_visible);
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline bool operator==(const xmasked_value<T1, B1>& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>
+    inline bool operator==(const T1& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return rhs.equal(lhs);
+    }
+
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>
+    inline bool operator==(const xmasked_value<T1, B1>& lhs, const T2& rhs) noexcept
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline bool operator!=(const xmasked_value<T1, B1>& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return !lhs.equal(rhs);
+    }
+
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>
+    inline bool operator!=(const T1& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return !rhs.equal(lhs);
+    }
+
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>
+    inline bool operator!=(const xmasked_value<T1, B1>& lhs, const T2& rhs) noexcept
+    {
+        return !lhs.equal(rhs);
+    }
+
+    template <class T, class B>
+    inline auto operator+(const xmasked_value<T, B>& e) noexcept
+        -> xmasked_value<std::decay_t<T>, std::decay_t<B>>
+    {
+        return xmasked_value<std::decay_t<T>, std::decay_t<B>>(e.value(), e.visible());
+    }
+
+    template <class T, class B>
+    inline auto operator-(const xmasked_value<T, B>& e) noexcept
+        -> xmasked_value<std::decay_t<T>, std::decay_t<B>>
+    {
+        return xmasked_value<std::decay_t<T>, std::decay_t<B>>(-e.value(), e.visible());
+    }
+
+    template <class T, class B>
+    inline auto operator~(const xmasked_value<T, B>& e) noexcept
+        -> xmasked_value<std::decay_t<T>>
+    {
+        using value_type = std::decay_t<T>;
+        return e.visible() ? masked_value(~e.value()) : masked<value_type>();
+    }
+
+    template <class T, class B>
+    inline auto operator!(const xmasked_value<T, B>& e) noexcept
+    {
+        return e.visible() ? masked_value(!e.value()) : masked<decltype(!e.value())>();
+    }
+
+    template <class T, class B, class OC, class OT>
+    inline std::basic_ostream<OC, OT>& operator<<(std::basic_ostream<OC, OT>& out, xmasked_value<T, B> v)
+    {
+        if (v.visible())
+        {
+            out << v.value();
+        }
+        else
+        {
+            out << "masked";
+        }
+        return out;
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline void swap(xmasked_value<T1, B1>& lhs, xmasked_value<T2, B2>& rhs)
+    {
+        lhs.swap(rhs);
+    }
+
+#define DEFINE_OPERATOR(OP)                                                                                   \
+    template <class T1, class B1, class T2, class B2>                                                         \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2) noexcept        \
+        -> xmasked_value<promote_type_t<std::decay_t<T1>, std::decay_t<T2>>>                                  \
+    {                                                                                                         \
+        using value_type = promote_type_t<std::decay_t<T1>, std::decay_t<T2>>;                                \
+        return e1.visible() && e2.visible() ? masked_value(e1.value() OP e2.value()) : masked<value_type>();  \
+    }                                                                                                         \
+                                                                                                              \
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>                     \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const T2& e2) noexcept                           \
+        -> xmasked_value<promote_type_t<std::decay_t<T1>, std::decay_t<T2>>>                                  \
+    {                                                                                                         \
+        using value_type = promote_type_t<std::decay_t<T1>, std::decay_t<T2>>;                                \
+        return e1.visible() ? masked_value(e1.value() OP e2) : masked<value_type>();                          \
+    }                                                                                                         \
+                                                                                                              \
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>                     \
+    inline auto operator OP(const T1& e1, const xmasked_value<T2, B2>& e2) noexcept                           \
+        -> xmasked_value<promote_type_t<std::decay_t<T1>, std::decay_t<T2>>>                                  \
+    {                                                                                                         \
+        using value_type = promote_type_t<std::decay_t<T1>, std::decay_t<T2>>;                                \
+        return e2.visible() ? masked_value(e1 OP e2.value()) : masked<value_type>();                          \
+    }
+
+#define DEFINE_BOOL_OPERATOR(OP)                                                                           \
+    template <class T1, class B1, class T2, class B2>                                                      \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2) noexcept     \
+        -> xmasked_value<decltype(e1.value() OP e2.value())>                                               \
+    {                                                                                                      \
+        return e1.visible() && e2.visible() ?                                                              \
+            masked_value(e1.value() OP e2.value()) :                                                       \
+            masked<decltype(e1.value() OP e2.value())>();                                                  \
+    }                                                                                                      \
+                                                                                                           \
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>                  \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const T2& e2) noexcept                        \
+        -> xmasked_value<decltype(e1.value() OP e2)>                                                       \
+    {                                                                                                      \
+        return e1.visible() ? masked_value(e1.value() OP e2) : masked<decltype(e1.value() OP e2)>();       \
+    }                                                                                                      \
+                                                                                                           \
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>                  \
+    inline auto operator OP(const T1& e1, const xmasked_value<T2, B2>& e2) noexcept                        \
+        -> xmasked_value<decltype(e1 OP e2.value())>                                                       \
+    {                                                                                                      \
+        return e2.visible() ? masked_value(e1 OP e2.value()) : masked<decltype(e1 OP e2.value())>();       \
+    }
+
+#define DEFINE_UNARY_OPERATOR(OP)                                                     \
+    template <class T, class B>                                                       \
+    inline xmasked_value<std::decay_t<T>> OP(const xmasked_value<T, B>& e)            \
+    {                                                                                 \
+        using std::OP;                                                                \
+        return e.visible() ? masked_value(OP(e.value())) : masked<std::decay_t<T>>(); \
+    }
+
+#define DEFINE_UNARY_BOOL_OPERATOR(OP)                                                        \
+    template <class T, class B>                                                               \
+    inline auto OP(const xmasked_value<T, B>& e)                                              \
+    {                                                                                         \
+        using std::OP;                                                                        \
+        return e.visible() ? masked_value(OP(e.value())) : masked<decltype(OP(e.value()))>(); \
+    }
+
+#define DEFINE_BINARY_OPERATOR(OP)                                                                       \
+    template <class T1, class B1, class T2, class B2>                                                    \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2)                     \
+    {                                                                                                    \
+        using std::OP;                                                                                   \
+        return e1.visible() && e2.visible() ?                                                            \
+            masked_value(OP(e1.value(), e2.value())) :                                                   \
+            masked<decltype(OP(e1.value(), e2.value()))>();                                              \
+    }                                                                                                    \
+                                                                                                         \
+    template <class T1, class B1, class T2>                                                              \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const T2& e2)                                        \
+    {                                                                                                    \
+        using std::OP;                                                                                   \
+        return e1.visible() ? masked_value(OP(e1.value(), e2)) : masked<decltype(OP(e1.value(), e2))>(); \
+    }                                                                                                    \
+                                                                                                         \
+    template <class T1, class T2, class B2>                                                              \
+    inline auto OP(const T1& e1, const xmasked_value<T2, B2>& e2)                                        \
+    {                                                                                                    \
+        using std::OP;                                                                                   \
+        return e2.visible() ? masked_value(OP(e1, e2.value())) : masked<decltype(OP(e1, e2.value()))>(); \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MMM(OP)                                                                               \
+    template <class T1, class B1, class T2, class B2, class T3, class B3>                                             \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                                                                 \
+        using std::OP;                                                                                                \
+        return (e1.visible() && e2.visible() && e3.visible()) ?                                                       \
+                masked_value(OP(e1.value(), e2.value(), e3.value())) :                                                \
+                masked<decltype(OP(e1.value(), e2.value(), e3.value()))>();                                           \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MMT(OP)                                                              \
+    template <class T1, class B1, class T2, class B2, class T3>                                      \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2, const T3& e3)   \
+    {                                                                                                \
+        using std::OP;                                                                               \
+        return (e1.visible() && e2.visible()) ?                                                      \
+                masked_value(OP(e1.value(), e2.value(), e3)) :                                       \
+                masked<decltype(OP(e1.value(), e2.value(), e3))>();                                  \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MTM(OP)                                                            \
+    template <class T1, class B1, class T2, class T3, class B3>                                    \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const T2& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                                              \
+        using std::OP;                                                                             \
+        return (e1.visible() && e3.visible()) ?                                                    \
+                masked_value(OP(e1.value(), e2, e3.value())) :                                     \
+                masked<decltype(OP(e1.value(), e2, e3.value()))>();                                \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_TMM(OP)                                                            \
+    template <class T1, class T2, class B2, class T3, class B3>                                    \
+    inline auto OP(const T1& e1, const xmasked_value<T2, B2>& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                                              \
+        using std::OP;                                                                             \
+        return (e2.visible() && e3.visible()) ?                                                    \
+                masked_value(OP(e1, e2.value(), e3.value())) :                                     \
+                masked<decltype(OP(e1, e2.value(), e3.value()))>();                                \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_TTM(OP)                                         \
+    template <class T1, class T2, class T3, class B3>                           \
+    inline auto OP(const T1& e1, const T2& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                           \
+        using std::OP;                                                          \
+        return e3.visible() ?                                                   \
+            masked_value(OP(e1, e2, e3.value())) :                              \
+            masked<decltype(OP(e1, e2, e3.value()))>();                         \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_TMT(OP)                                         \
+    template <class T1, class T2, class B2, class T3>                           \
+    inline auto OP(const T1& e1, const xmasked_value<T2, B2>& e2, const T3& e3) \
+    {                                                                           \
+        using std::OP;                                                          \
+        return e2.visible() ?                                                   \
+            masked_value(OP(e1, e2.value(), e3)) :                              \
+            masked<decltype(OP(e1, e2.value(), e3))>();                         \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MTT(OP)                                         \
+    template <class T1, class B1, class T2, class T3>                           \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const T2& e2, const T3& e3) \
+    {                                                                           \
+        using std::OP;                                                          \
+        return e1.visible() ?                                                   \
+            masked_value(OP(e1.value(), e2, e3)) :                              \
+            masked<decltype(OP(e1.value(), e2, e3))>();                         \
+    }
+
+#define DEFINE_TERNARY_OPERATOR(OP) \
+    DEFINE_TERNARY_OPERATOR_MMM(OP) \
+                                    \
+    DEFINE_TERNARY_OPERATOR_MMT(OP) \
+    DEFINE_TERNARY_OPERATOR_MTM(OP) \
+    DEFINE_TERNARY_OPERATOR_TMM(OP) \
+    DEFINE_TERNARY_OPERATOR_TTM(OP) \
+    DEFINE_TERNARY_OPERATOR_TMT(OP) \
+    DEFINE_TERNARY_OPERATOR_MTT(OP)
+
+    DEFINE_OPERATOR(+);
+    DEFINE_OPERATOR(-);
+    DEFINE_OPERATOR(*);
+    DEFINE_OPERATOR(/);
+    DEFINE_OPERATOR(%);
+    DEFINE_BOOL_OPERATOR(||);
+    DEFINE_BOOL_OPERATOR(&&);
+    DEFINE_OPERATOR(&);
+    DEFINE_OPERATOR(|);
+    DEFINE_OPERATOR(^);
+    DEFINE_BOOL_OPERATOR(<);
+    DEFINE_BOOL_OPERATOR(<=);
+    DEFINE_BOOL_OPERATOR(>);
+    DEFINE_BOOL_OPERATOR(>=);
+    DEFINE_UNARY_OPERATOR(abs)
+    DEFINE_UNARY_OPERATOR(fabs)
+    DEFINE_UNARY_OPERATOR(exp)
+    DEFINE_UNARY_OPERATOR(exp2)
+    DEFINE_UNARY_OPERATOR(expm1)
+    DEFINE_UNARY_OPERATOR(log)
+    DEFINE_UNARY_OPERATOR(log10)
+    DEFINE_UNARY_OPERATOR(log2)
+    DEFINE_UNARY_OPERATOR(log1p)
+    DEFINE_UNARY_OPERATOR(sqrt)
+    DEFINE_UNARY_OPERATOR(cbrt)
+    DEFINE_UNARY_OPERATOR(sin)
+    DEFINE_UNARY_OPERATOR(cos)
+    DEFINE_UNARY_OPERATOR(tan)
+    DEFINE_UNARY_OPERATOR(acos)
+    DEFINE_UNARY_OPERATOR(asin)
+    DEFINE_UNARY_OPERATOR(atan)
+    DEFINE_UNARY_OPERATOR(sinh)
+    DEFINE_UNARY_OPERATOR(cosh)
+    DEFINE_UNARY_OPERATOR(tanh)
+    DEFINE_UNARY_OPERATOR(acosh)
+    DEFINE_UNARY_OPERATOR(asinh)
+    DEFINE_UNARY_OPERATOR(atanh)
+    DEFINE_UNARY_OPERATOR(erf)
+    DEFINE_UNARY_OPERATOR(erfc)
+    DEFINE_UNARY_OPERATOR(tgamma)
+    DEFINE_UNARY_OPERATOR(lgamma)
+    DEFINE_UNARY_OPERATOR(ceil)
+    DEFINE_UNARY_OPERATOR(floor)
+    DEFINE_UNARY_OPERATOR(trunc)
+    DEFINE_UNARY_OPERATOR(round)
+    DEFINE_UNARY_OPERATOR(nearbyint)
+    DEFINE_UNARY_OPERATOR(rint)
+    DEFINE_UNARY_BOOL_OPERATOR(isfinite)
+    DEFINE_UNARY_BOOL_OPERATOR(isinf)
+    DEFINE_UNARY_BOOL_OPERATOR(isnan)
+    DEFINE_BINARY_OPERATOR(fmod)
+    DEFINE_BINARY_OPERATOR(remainder)
+    DEFINE_BINARY_OPERATOR(fmax)
+    DEFINE_BINARY_OPERATOR(fmin)
+    DEFINE_BINARY_OPERATOR(fdim)
+    DEFINE_BINARY_OPERATOR(pow)
+    DEFINE_BINARY_OPERATOR(hypot)
+    DEFINE_BINARY_OPERATOR(atan2)
+    DEFINE_TERNARY_OPERATOR(fma)
+
+#undef DEFINE_TERNARY_OPERATOR
+#undef DEFINE_TERNARY_OPERATOR_MMM
+#undef DEFINE_TERNARY_OPERATOR_MMT
+#undef DEFINE_TERNARY_OPERATOR_MTM
+#undef DEFINE_TERNARY_OPERATOR_TMM
+#undef DEFINE_TERNARY_OPERATOR_TTM
+#undef DEFINE_TERNARY_OPERATOR_TMT
+#undef DEFINE_TERNARY_OPERATOR_MTT
+#undef DEFINE_BINARY_OPERATOR
+#undef DEFINE_UNARY_OPERATOR
+#undef DEFINE_UNARY_BOOL_OPERATOR
+#undef DEFINE_OPERATOR
+#undef DEFINE_BOOL_OPERATOR
+}
+
+#endif

--- a/include/xtl/xmasked_value.hpp
+++ b/include/xtl/xmasked_value.hpp
@@ -271,7 +271,7 @@ namespace xtl
     }
 
     template <class T, class B>
-    inline auto operator!(const xmasked_value<T, B>& e) noexcept
+    inline auto operator!(const xmasked_value<T, B>& e) noexcept -> xmasked_value<decltype(!e.value())>
     {
         using return_type = xmasked_value<decltype(!e.value())>;
         using value_type = typename return_type::value_type;

--- a/include/xtl/xmasked_value.hpp
+++ b/include/xtl/xmasked_value.hpp
@@ -273,7 +273,9 @@ namespace xtl
     template <class T, class B>
     inline auto operator!(const xmasked_value<T, B>& e) noexcept
     {
-        return e.visible() ? masked_value(!e.value()) : masked<decltype(!e.value())>();
+        using return_type = xmasked_value<decltype(!e.value())>;
+        using value_type = typename return_type::value_type;
+        return e.visible() ? return_type(!e.value()) : masked<value_type>();
     }
 
     template <class T, class B, class OC, class OT>

--- a/include/xtl/xmasked_value_meta.hpp
+++ b/include/xtl/xmasked_value_meta.hpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+* Copyright (c) 2019, Johan Mabille, Sylvain Corlay, Wolf Vollprecht and   *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_XMASKED_VALUE_META_HPP
+#define XTL_XMASKED_VALUE_META_HPP
+
+namespace xtl
+{
+    template <class T, class B = bool>
+    class xmasked_value;
+
+    namespace detail
+    {
+        template <class E>
+        struct is_xmasked_value_impl : std::false_type
+        {
+        };
+
+        template <class T, class B>
+        struct is_xmasked_value_impl<xmasked_value<T, B>> : std::true_type
+        {
+        };
+    }
+
+    template <class E>
+    using is_xmasked_value = detail::is_xmasked_value_impl<E>;
+
+    template <class E, class R>
+    using disable_xmasked_value = std::enable_if_t<!is_xmasked_value<E>::value, R>;
+}
+
+#endif

--- a/include/xtl/xoptional_meta.hpp
+++ b/include/xtl/xoptional_meta.hpp
@@ -1,0 +1,135 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay, Wolf Vollprecht and   *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_OPTIONAL_META_HPP
+#define XTL_OPTIONAL_META_HPP
+
+#include <type_traits>
+
+#include "xmasked_value_meta.hpp"
+#include "xmeta_utils.hpp"
+#include "xtype_traits.hpp"
+
+namespace xtl
+{
+    template <class CT, class CB = bool>
+    class xoptional;
+
+    namespace detail
+    {
+        template <class E>
+        struct is_xoptional_impl : std::false_type
+        {
+        };
+
+        template <class CT, class CB>
+        struct is_xoptional_impl<xoptional<CT, CB>> : std::true_type
+        {
+        };
+
+        template <class CT, class CTO, class CBO>
+        using converts_from_xoptional = disjunction<
+            std::is_constructible<CT, const xoptional<CTO, CBO>&>,
+            std::is_constructible<CT, xoptional<CTO, CBO>&>,
+            std::is_constructible<CT, const xoptional<CTO, CBO>&&>,
+            std::is_constructible<CT, xoptional<CTO, CBO>&&>,
+            std::is_convertible<const xoptional<CTO, CBO>&, CT>,
+            std::is_convertible<xoptional<CTO, CBO>&, CT>,
+            std::is_convertible<const xoptional<CTO, CBO>&&, CT>,
+            std::is_convertible<xoptional<CTO, CBO>&&, CT>
+        >;
+
+        template <class CT, class CTO, class CBO>
+        using assigns_from_xoptional = disjunction<
+            std::is_assignable<std::add_lvalue_reference_t<CT>, const xoptional<CTO, CBO>&>,
+            std::is_assignable<std::add_lvalue_reference_t<CT>, xoptional<CTO, CBO>&>,
+            std::is_assignable<std::add_lvalue_reference_t<CT>, const xoptional<CTO, CBO>&&>,
+            std::is_assignable<std::add_lvalue_reference_t<CT>, xoptional<CTO, CBO>&&>
+        >;
+
+        template <class... Args>
+        struct common_optional_impl;
+
+        template <class T>
+        struct common_optional_impl<T>
+        {
+            using type = std::conditional_t<is_xoptional_impl<T>::value, T, xoptional<T>>;
+        };
+
+        template <class T>
+        struct identity
+        {
+            using type = T;
+        };
+
+        template <class T>
+        struct get_value_type
+        {
+            using type = typename T::value_type;
+        };
+
+        template<class T1, class T2>
+        struct common_optional_impl<T1, T2>
+        {
+            using decay_t1 = std::decay_t<T1>;
+            using decay_t2 = std::decay_t<T2>;
+            using type1 = xtl::mpl::eval_if_t<std::is_fundamental<decay_t1>, identity<decay_t1>, get_value_type<decay_t1>>;
+            using type2 = xtl::mpl::eval_if_t<std::is_fundamental<decay_t2>, identity<decay_t2>, get_value_type<decay_t2>>;
+            using type = xoptional<std::common_type_t<type1, type2>>;
+        };
+
+        template <class T1, class T2, class B2>
+        struct common_optional_impl<T1, xoptional<T2, B2>>
+            : common_optional_impl<T1, T2>
+        {
+        };
+
+        template <class T1, class B1, class T2>
+        struct common_optional_impl<xoptional<T1, B1>, T2>
+            : common_optional_impl<T1, T2>
+        {
+        };
+
+        template <class T1, class B1, class T2, class B2>
+        struct common_optional_impl<xoptional<T1, B1>, xoptional<T2, B2>>
+            : common_optional_impl<T1, T2>
+        {
+        };
+
+        template <class T1, class T2, class... Args>
+        struct common_optional_impl<T1, T2, Args...>
+        {
+            using type = typename common_optional_impl<
+                             typename common_optional_impl<T1, T2>::type,
+                             Args...
+                         >::type;
+        };
+    }
+
+    template <class E>
+    using is_xoptional = detail::is_xoptional_impl<E>;
+
+    template <class E, class R = void>
+    using disable_xoptional = std::enable_if_t<!is_xoptional<E>::value, R>;
+
+    template <class... Args>
+    struct common_optional : detail::common_optional_impl<Args...>
+    {
+    };
+
+    template <class... Args>
+    using common_optional_t = typename common_optional<Args...>::type;
+
+    template <class E>
+    struct is_not_xoptional_nor_xmasked_value : negation<disjunction<is_xoptional<E>, is_xmasked_value<E>>>
+    {
+    };
+}
+
+#endif

--- a/include/xtl/xtype_traits.hpp
+++ b/include/xtl/xtype_traits.hpp
@@ -10,11 +10,157 @@
 #define XTL_TYPE_TRAITS_HPP
 
 #include <type_traits>
+#include <complex>
 
 #include "xtl_config.hpp"
 
 namespace xtl
 {
+    /************************************
+     * arithmetic type promotion traits *
+     ************************************/
+
+    /**
+     * Traits class for the result type of mixed arithmetic expressions.
+     * For example, <tt>promote_type<unsigned char, unsigned char>::type</tt> tells
+     * the user that <tt>unsigned char + unsigned char => int</tt>.
+     */
+    template <class... T>
+    struct promote_type;
+
+    template <>
+    struct promote_type<>
+    {
+        using type = void;
+    };
+
+    template <class T>
+    struct promote_type<T>
+    {
+        using type = typename promote_type<T, T>::type;
+    };
+
+    template <class T0, class T1>
+    struct promote_type<T0, T1>
+    {
+        using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<std::decay_t<T1>>());
+    };
+
+    template <class T0, class... REST>
+    struct promote_type<T0, REST...>
+    {
+        using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<typename promote_type<REST...>::type>());
+    };
+
+    template <>
+    struct promote_type<bool>
+    {
+        using type = bool;
+    };
+
+    template <class T>
+    struct promote_type<bool, T>
+    {
+        using type = T;
+    };
+
+    template <class... REST>
+    struct promote_type<bool, REST...>
+    {
+        using type = typename promote_type<bool, typename promote_type<REST...>::type>::type;
+    };
+
+    /**
+     * Abbreviation of 'typename promote_type<T>::type'.
+     */
+    template <class... T>
+    using promote_type_t = typename promote_type<T...>::type;
+
+    /**
+     * Traits class to find the biggest type of the same kind.
+     *
+     * For example, <tt>big_promote_type<unsigned char>::type</tt> is <tt>unsigned long long</tt>.
+     * The default implementation only supports built-in types and <tt>std::complex</tt>. All
+     * other types remain unchanged unless <tt>big_promote_type</tt> gets specialized for them.
+     */
+    template <class T>
+    struct big_promote_type
+    {
+    private:
+
+        using V = std::decay_t<T>;
+        static constexpr bool is_arithmetic = std::is_arithmetic<V>::value;
+        static constexpr bool is_signed = std::is_signed<V>::value;
+        static constexpr bool is_integral = std::is_integral<V>::value;
+        static constexpr bool is_long_double = std::is_same<V, long double>::value;
+
+    public:
+
+        using type = std::conditional_t<is_arithmetic,
+                        std::conditional_t<is_integral,
+                            std::conditional_t<is_signed, long long, unsigned long long>,
+                            std::conditional_t<is_long_double, long double, double>
+                        >,
+                        V
+                     >;
+    };
+
+    template <class T>
+    struct big_promote_type<std::complex<T>>
+    {
+        using type = std::complex<typename big_promote_type<T>::type>;
+    };
+
+    /**
+     * Abbreviation of 'typename big_promote_type<T>::type'.
+     */
+    template <class T>
+    using big_promote_type_t = typename big_promote_type<T>::type;
+
+    namespace traits_detail
+    {
+        using std::sqrt;
+
+        template <class T>
+        using real_promote_type_t = decltype(sqrt(std::declval<std::decay_t<T>>()));
+    }
+
+    /**
+     * Result type of algebraic expressions.
+     *
+     * For example, <tt>real_promote_type<int>::type</tt> tells the
+     * user that <tt>sqrt(int) => double</tt>.
+     */
+    template <class T>
+    struct real_promote_type
+    {
+        using type = traits_detail::real_promote_type_t<T>;
+    };
+
+    /**
+     * Abbreviation of 'typename real_promote_type<T>::type'.
+     */
+    template <class T>
+    using real_promote_type_t = typename real_promote_type<T>::type;
+
+    /**
+     * Traits class to replace 'bool' with 'uint8_t' and keep everything else.
+     *
+     * This is useful for scientific computing, where a boolean mask array is
+     * usually implemented as an array of bytes.
+     */
+    template <class T>
+    struct bool_promote_type
+    {
+        using type = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
+    };
+
+    /**
+     * Abbreviation for typename bool_promote_type<T>::type
+     */
+    template <class T>
+    using bool_promote_type_t = typename bool_promote_type<T>::type;
+
     /************
      * apply_cv *
      ************/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,6 +95,7 @@ set(XTL_TESTS
     test_xhash.cpp
     test_xhierarchy_generator.cpp
     test_xiterator_base.cpp
+    test_xmasked_value.cpp
     test_xmeta_utils.cpp
     test_xoptional.cpp
     test_xsequence.cpp

--- a/test/test_xmasked_value.cpp
+++ b/test/test_xmasked_value.cpp
@@ -9,8 +9,8 @@
 
 #include "gtest/gtest.h"
 
-#include "xtl/xmasked_value.hpp"
 #include "xtl/xoptional.hpp"
+#include "xtl/xmasked_value.hpp"
 
 namespace xtl
 {

--- a/test/test_xmasked_value.cpp
+++ b/test/test_xmasked_value.cpp
@@ -1,0 +1,622 @@
+/***************************************************************************
+* Copyright (c) 2017, Johan Mabille, Sylvain Corlay Wolf Vollprecht and    *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+
+#include "xtl/xmasked_value.hpp"
+#include "xtl/xoptional.hpp"
+
+namespace xtl
+{
+    using optional_type = xoptional<double&, bool&>;
+
+    TEST(xmasked_value, ctor)
+    {
+        double a = 5.2;
+
+        auto m = xmasked_value<double&>(a);
+        EXPECT_EQ(m.value(), 5.2);
+        EXPECT_EQ(m.visible(), true);
+    }
+
+    TEST(xmasked_value, value)
+    {
+        double a = 5.2;
+        bool bool_val = true;
+
+        auto b = optional_type(a, bool_val);
+        auto c = xmasked_value<optional_type>(b);
+
+        EXPECT_EQ(c.value(), 5.2);
+        a = 3.35;
+        EXPECT_EQ(c.value(), 3.35);
+        c.value() = 126.;
+        EXPECT_EQ(c.value(), 126.);
+        EXPECT_EQ(a, 126.);
+
+        auto c2 = xmasked_value<double>(3.);
+        EXPECT_EQ(c2.value(), 3.);
+        c2.value() = 36.;
+        EXPECT_EQ(c2.value(), 36.);
+    }
+
+    TEST(xmasked_value, visible)
+    {
+        double a = 5.2;
+        bool bool_val = true;
+
+        auto b = optional_type(a, bool_val);
+        auto c = xmasked_value<optional_type, bool&>(b, bool_val);
+
+        EXPECT_TRUE(c.visible());
+        bool_val = false;
+        EXPECT_FALSE(c.visible());
+    }
+
+    TEST(xmasked_value, conversion)
+    {
+        double a = 5.2;
+        bool bool_val = true;
+
+        auto b = xmasked_value<double&, bool&>(a, bool_val);
+
+        xoptional<double&, bool> c = b;
+        EXPECT_EQ(c.value(), 5.2);
+        EXPECT_TRUE(c.has_value());
+
+        double& val = b;
+        EXPECT_EQ(val, 5.2);
+        val = 36.;
+        EXPECT_EQ(c.value(), 36.);
+        EXPECT_EQ(b.value(), 36.);
+    }
+
+    TEST(xmasked_value, comparison)
+    {
+        double a = 5.2;
+        bool bool_val = true;
+
+        auto m1 = xmasked_value<double&, bool&>(a, bool_val);
+        auto m2 = xmasked_value<double&, bool&>(a, bool_val);
+
+        EXPECT_EQ(m1, m2);
+        EXPECT_EQ(m2, m1);
+
+        EXPECT_EQ(m1, 5.2);
+        EXPECT_EQ(5.2, m1);
+
+        EXPECT_NE(m1, 6.2);
+        EXPECT_NE(6.2, m1);
+
+        bool_val = false;
+
+        EXPECT_NE(m1, 5.2);
+        EXPECT_NE(5.2, m1);
+
+        using opt_type = xoptional<double, bool>;
+        using masked_opt_type = xmasked_value<opt_type>;
+
+        auto masked1 = masked_opt_type(opt_type(5.2));
+        auto o1 = opt_type(5.2);
+
+        EXPECT_EQ(masked1, o1);
+        EXPECT_EQ(masked1, 5.2);
+
+        masked1.visible() = false;
+        EXPECT_NE(masked1, o1);
+    }
+
+    TEST(xmasked_value, swap)
+    {
+        double a1 = 5.2;
+        bool b1 = true;
+        double a2 = 36.5;
+        bool b2 = false;
+
+        auto m1 = xmasked_value<double&, bool&>(a1, b1);
+        auto m2 = xmasked_value<double&, bool&>(a2, b2);
+
+        EXPECT_EQ(a1, 5.2);
+        EXPECT_EQ(b1, true);
+        EXPECT_EQ(a2, 36.5);
+        EXPECT_EQ(b2, false);
+
+        m1.swap(m2);
+
+        EXPECT_EQ(a1, 36.5);
+        EXPECT_EQ(b1, false);
+        EXPECT_EQ(a2, 5.2);
+        EXPECT_EQ(b2, true);
+
+        using opt_type = xoptional<double>;
+
+        auto o1 = opt_type(3.5, true);
+        auto o2 = opt_type(6.5, false);
+        auto m3 = xmasked_value<opt_type>(o1, true);
+        auto m4 = xmasked_value<opt_type>(o2, false);
+
+        swap(m3, m4);
+
+        EXPECT_EQ(m3.value().value(), 6.5);
+        EXPECT_FALSE(m3.value().has_value());
+        EXPECT_FALSE(m3.visible());
+        EXPECT_EQ(m4.value().value(), 3.5);
+        EXPECT_TRUE(m4.value().has_value());
+        EXPECT_TRUE(m4.visible());
+    }
+
+    TEST(xmasked_value, arithm_neg)
+    {
+        double a = 5.2;
+        bool b = true;
+
+        auto m = xmasked_value<double&, bool&>(a, b);
+
+        xmasked_value<double, bool> r = -m;
+        EXPECT_EQ(r.value(), -5.2);
+        EXPECT_EQ(r.visible(), true);
+    }
+
+    TEST(xmasked_value, arithm_plus)
+    {
+        double a = 5.2;
+        bool b = true;
+
+        auto o = optional_type(a, b);
+
+        auto m = xmasked_value<optional_type>(o);
+
+        auto r1 = m + o;
+        EXPECT_EQ(r1.value(), 10.4);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o + m;
+        EXPECT_EQ(r2.value(), 10.4);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m + m;
+        EXPECT_EQ(r3.value(), 10.4);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 4.2 + m;
+        EXPECT_EQ(r4.value(), 9.4);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m + 4.2;
+        EXPECT_EQ(r5.value(), 9.4);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, arithm_minus)
+    {
+        double a = 5.2;
+        bool b = true;
+
+        auto o = optional_type(a, b);
+
+        auto m = xmasked_value<optional_type>(o);
+
+        auto r1 = m - o;
+        EXPECT_EQ(r1.value(), 0.0);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o - m;
+        EXPECT_EQ(r2.value(), 0.0);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m - m;
+        EXPECT_EQ(r3.value(), 0.0);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 4.2 - m;
+        EXPECT_EQ(r4.value(), -1.0);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m - 4.2;
+        EXPECT_EQ(r5.value(), 1.0);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, arithm_mult)
+    {
+        double a = 5.0;
+        bool b = true;
+
+        auto o = optional_type(a, b);
+
+        auto m = xmasked_value<optional_type>(o);
+
+        auto r1 = m * o;
+        EXPECT_EQ(r1.value(), 25.);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o * m;
+        EXPECT_EQ(r2.value(), 25.);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m * m;
+        EXPECT_EQ(r3.value(), 25.);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 4. * m;
+        EXPECT_EQ(r4.value(), 20.);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m * 4.;
+        EXPECT_EQ(r5.value(), 20.);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, arithm_div)
+    {
+        double a = 5.0;
+        bool b = true;
+
+        auto o = optional_type(a, b);
+
+        auto m = xmasked_value<optional_type>(o);
+
+        auto r1 = m / o;
+        EXPECT_EQ(r1.value(), 1.);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o / m;
+        EXPECT_EQ(r2.value(), 1.);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m / m;
+        EXPECT_EQ(r3.value(), 1.);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 25. / m;
+        EXPECT_EQ(r4.value(), 5.);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m / 1.;
+        EXPECT_EQ(r5.value(), 5.);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, operator_or)
+    {
+        bool b = true;
+
+        auto o = xoptional<bool, bool&>(true, b);
+        auto m = xmasked_value<xoptional<bool, bool&>, bool>(o, true);
+
+        auto r1 = m || o;
+        EXPECT_EQ(r1.value(), true);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o || m;
+        EXPECT_EQ(r2.value(), true);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m || m;
+        EXPECT_EQ(r3.value(), true);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = true || m;
+        EXPECT_EQ(r4.value(), true);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = false || m;
+        EXPECT_EQ(r5.value(), true);
+        EXPECT_EQ(r5.visible(), true);
+
+        auto r6 = m || true;
+        EXPECT_EQ(r6.value(), true);
+        EXPECT_EQ(r6.visible(), true);
+
+        auto r7 = m || false;
+        EXPECT_EQ(r7.value(), true);
+        EXPECT_EQ(r7.visible(), true);
+    }
+
+    TEST(xmasked_value, operator_and)
+    {
+        bool b = true;
+
+        auto o = xoptional<bool, bool&>(true, b);
+        auto m = xmasked_value<xoptional<bool, bool&>, bool>(o, true);
+
+        auto r1 = m && o;
+        EXPECT_EQ(r1.value(), true);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o && m;
+        EXPECT_EQ(r2.value(), true);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m && m;
+        EXPECT_EQ(r3.value(), true);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = true && m;
+        EXPECT_EQ(r4.value(), true);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = false && m;
+        EXPECT_EQ(r5.value(), false);
+        EXPECT_EQ(r5.visible(), true);
+
+        auto r6 = m && true;
+        EXPECT_EQ(r6.value(), true);
+        EXPECT_EQ(r6.visible(), true);
+
+        auto r7 = m && false;
+        EXPECT_EQ(r7.value(), false);
+        EXPECT_EQ(r7.visible(), true);
+
+        m.visible() = false;
+        auto r8 = m && true;
+        EXPECT_EQ(r8.visible(), false);
+    }
+
+    TEST(xmasked_value, operator_not)
+    {
+        using opt_type = xoptional<bool>;
+
+        bool b = true;
+
+        auto m1 = xmasked_value<bool, bool&>(true, b);
+        auto m2 = xmasked_value<bool, bool&>(false, b);
+        auto m3 = xmasked_value<opt_type>(opt_type(true));
+
+        EXPECT_EQ(!m1, false);
+        EXPECT_EQ(!m2, true);
+        EXPECT_EQ(!m3, false);
+    }
+
+    TEST(xmasked_value, operator_less)
+    {
+        double a1 = 5.0;
+        double a2 = 10.0;
+        bool b = true;
+
+        auto o = optional_type(a1, b);
+        auto o2 = optional_type(a2, b);
+
+        auto m = xmasked_value<optional_type, bool>(o2, true);
+
+        auto r1 = m < o;
+        EXPECT_EQ(r1.value(), false);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o < m;
+        EXPECT_EQ(r2.value(), true);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m < m;
+        EXPECT_EQ(r3.value(), false);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 25. < m;
+        EXPECT_EQ(r4.value(), false);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m < 25.;
+        EXPECT_EQ(r5.value(), true);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, operator_less_equal)
+    {
+        double a1 = 5.0;
+        double a2 = 10.0;
+        bool b = true;
+
+        auto o = optional_type(a1, b);
+        auto o2 = optional_type(a2, b);
+
+        auto m = xmasked_value<optional_type, bool>(o2, true);
+
+        auto r1 = m <= o;
+        EXPECT_EQ(r1.value(), false);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o <= m;
+        EXPECT_EQ(r2.value(), true);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m <= m;
+        EXPECT_EQ(r3.value(), true);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 25. <= m;
+        EXPECT_EQ(r4.value(), false);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m <= 25.;
+        EXPECT_EQ(r5.value(), true);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, operator_more)
+    {
+        double a1 = 5.0;
+        double a2 = 10.0;
+        bool b = true;
+
+        auto o = optional_type(a1, b);
+        auto o2 = optional_type(a2, b);
+
+        auto m = xmasked_value<optional_type, bool&>(o2, b);
+
+        auto r1 = m > o;
+        EXPECT_EQ(r1.value(), true);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o > m;
+        EXPECT_EQ(r2.value(), false);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m > m;
+        EXPECT_EQ(r3.value(), false);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 25. > m;
+        EXPECT_EQ(r4.value(), true);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m > 25.;
+        EXPECT_EQ(r5.value(), false);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, operator_more_equal)
+    {
+        double a1 = 5.0;
+        double a2 = 10.0;
+        bool b = true;
+
+        auto o = optional_type(a1, b);
+        auto o2 = optional_type(a2, b);
+
+        auto m = xmasked_value<optional_type, bool&>(o2, b);
+
+        auto r1 = m >= o;
+        EXPECT_EQ(r1.value(), true);
+        EXPECT_EQ(r1.visible(), true);
+
+        auto r2 = o >= m;
+        EXPECT_EQ(r2.value(), false);
+        EXPECT_EQ(r2.visible(), true);
+
+        auto r3 = m >= m;
+        EXPECT_EQ(r3.value(), true);
+        EXPECT_EQ(r3.visible(), true);
+
+        auto r4 = 25. >= m;
+        EXPECT_EQ(r4.value(), true);
+        EXPECT_EQ(r4.visible(), true);
+
+        auto r5 = m >= 25.;
+        EXPECT_EQ(r5.value(), false);
+        EXPECT_EQ(r5.visible(), true);
+    }
+
+    TEST(xmasked_value, assign)
+    {
+        double a = 5.2;
+        double a2 = 3.35;
+        bool bool_val = true;
+
+        auto b = optional_type(a, bool_val);
+        auto c = xmasked_value<optional_type>(b);
+
+        // Value not masked, assigning a value works
+        EXPECT_EQ(c.value(), 5.2);
+        c = a2;
+        EXPECT_EQ(c.value(), 3.35);
+        EXPECT_EQ(a, 3.35);
+        c += 1.;
+        EXPECT_EQ(c.value(), 4.35);
+        EXPECT_EQ(a, 4.35);
+        c -= 1.;
+        c *= 2.;
+        EXPECT_NEAR(a, 6.7, 0.0001);
+        c -= b;
+        EXPECT_NEAR(a, 0., 0.0001);
+        c = 3.35;
+
+        // When masked, the assign doesn't do anything
+        c.visible() = false;
+        c = 126.;
+        EXPECT_EQ(c.value(), 3.35);
+        EXPECT_EQ(a, 3.35);
+        c *= 126;
+        EXPECT_EQ(c.value(), 3.35);
+        EXPECT_EQ(a, 3.35);
+    }
+
+    TEST(xmasked_value, unary_op)
+    {
+        double a1 = -5.2;
+        double a2 = 5.2;
+        bool bool_val = true;
+
+        auto m1 = xmasked_value<double&, bool&>(a1, bool_val);
+        auto m2 = xmasked_value<double&, bool&>(a2, bool_val);
+
+        EXPECT_EQ(abs(m1).value(), 5.2);
+        EXPECT_EQ(abs(m2).value(), 5.2);
+    }
+
+    TEST(xmasked_value, unary_bool_op)
+    {
+        double a = -5.2;
+        bool bool_val = true;
+
+        auto m = xmasked_value<double&, bool&>(a, bool_val);
+
+        EXPECT_EQ(isfinite(m).value(), true);
+    }
+
+    TEST(xmasked_value, binary_op)
+    {
+        double a1 = 5.0;
+        double a2 = 5.0;
+        bool bool_val = true;
+
+        auto o = xoptional<double&>(a1);
+        auto m1 = xmasked_value<xoptional<double&>, bool&>(o, bool_val);
+        auto m2 = xmasked_value<double&, bool&>(a2, bool_val);
+
+        EXPECT_EQ(pow(m1, m1).value(), std::pow(5., 5.));
+        EXPECT_EQ(pow(m1, o).value(), std::pow(5., 5.));
+        EXPECT_EQ(pow(o, m1).value(), std::pow(5., 5.));
+        EXPECT_EQ(pow(m1, 2).value(), 25.0);
+        EXPECT_EQ(pow(2, m1).value(), 32);
+    }
+
+    TEST(xmasked_value, ternary_op)
+    {
+        double a1 = 5.0;
+        double a2 = 11.0;
+        bool bool_val = true;
+
+        auto m1 = xmasked_value<double&, bool&>(a1, bool_val);
+        auto m2 = xmasked_value<double&, bool&>(a2, bool_val);
+        auto masked1 = masked<double>();
+
+        EXPECT_EQ(fma(m1, m2, m2).value(), 66.);
+        EXPECT_EQ(fma(m1, masked1, m2), masked1);
+
+        EXPECT_EQ(fma(m1, m2, 2.).value(), 57.);
+        EXPECT_EQ(fma(m1, 2., m2).value(), 21.);
+        EXPECT_EQ(fma(2., m1, m2).value(), 21.);
+        EXPECT_EQ(fma(2., 10., m2).value(), 31.);
+        EXPECT_EQ(fma(2., m2, 3.).value(), 25.);
+        EXPECT_EQ(fma(m2, 5., 3.).value(), 58.);
+        EXPECT_EQ(fma(m2, 5., masked1), masked1);
+
+        auto o = xoptional<double>(2.);
+        auto o1 = xoptional<double>(5.);
+        auto o2 = xoptional<double>(11.);
+        auto m3 = xmasked_value<xoptional<double>, bool&>(o1, bool_val);
+        auto m4 = xmasked_value<xoptional<double>, bool&>(o2, bool_val);
+        auto masked2 = masked<xoptional<double>>();
+
+        EXPECT_EQ(fma(m3, m4, o).value(), 57.);
+        EXPECT_EQ(fma(m3, o, m4).value(), 21.);
+        EXPECT_EQ(fma(o, m3, m4).value(), 21.);
+        EXPECT_EQ(fma(o, m3, masked2), masked2);
+        EXPECT_EQ(fma(o, o, m4).value(), 15.);
+        EXPECT_EQ(fma(o, m4, o).value(), 24.);
+        EXPECT_EQ(fma(m4, o, o).value(), 24.);
+
+        EXPECT_EQ(fma(3., m4, o).value(), 35.);
+        EXPECT_EQ(fma(m4, 3., o).value(), 35.);
+        EXPECT_EQ(fma(m4, o, 3.).value(), 25.);
+        EXPECT_EQ(fma(o, m4, 3.).value(), 25.);
+        EXPECT_EQ(fma(o, 3., m3).value(), 11.);
+        EXPECT_EQ(fma(3., o, m3).value(), 11.);
+    }
+}


### PR DESCRIPTION
I moved the xmasked_value implementation from xtensor to xtl. Also removing code related to xoptionals in xmasked_value (basically all the special cases concerning xoptionals), now xmasked_value does not depend on xoptionals anymore.
Operators defined in xoptionals are disabled when applied on a mix of xoptionals and xmasked_values (in order to prevent ambiguity with operators defined in xmasked_value).
Typically:
```c++
using opt_type = xoptional<double>;

auto m = xmasked_value<opt_type>(opt_type(3.));
auto o = opt_type(2.);

auto res = m + o; // Calls operator+ from xmasked_value, res is an xmasked_value<opt_type>
```