### PR TITLE
Allow xtl to build with -fno-exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ enable_testing()
 
 set(XTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# Versionning
+# Versioning
 # ===========
 
 file(STRINGS "${XTL_INCLUDE_DIR}/xtl/xtl_config.hpp" xtl_version_defines
@@ -72,8 +72,9 @@ target_include_directories(xtl INTERFACE $<BUILD_INTERFACE:${XTL_INCLUDE_DIR}>
 target_compile_features(xtl INTERFACE cxx_std_14)
 
 
-OPTION(BUILD_TESTS "xtl test suite" OFF)
-OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
+option(BUILD_TESTS "xtl test suite" OFF)
+option(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
+option(XTL_DISABLE_EXCEPTIONS "Disable C++ exceptions" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)

--- a/docs/source/build-options.rst
+++ b/docs/source/build-options.rst
@@ -15,6 +15,7 @@ Build
 - ``BUILD_TESTS``: enables the ``xtest`` target (see below).
 - ``DOWNLOAD_GTEST``: downloads ``gtest`` and builds it locally instead of using a binary installation.
 - ``GTEST_SRC_DIR``: indicates where to find the ``gtest`` sources instead of downloading them.
+- ``XTL_DISABLE_EXCEPTIONS``: indicates that tests should be run with exceptions disabled.
 
 All these options are disabled by default. Enabling ``DOWNLOAD_GTEST`` or setting ``GTEST_SRC_DIR``
 enables ``BUILD_TESTS``.

--- a/include/xtl/xany.hpp
+++ b/include/xtl/xany.hpp
@@ -36,6 +36,19 @@ namespace xtl
         }
     };
 
+    namespace detail {
+        inline static void check_any_cast(void* p) {
+            if (p == nullptr) {
+#if defined(XTL_NO_EXCEPTIONS)
+                std::fprintf(stderr, "bad_any_cast\n");
+                std::terminate();        
+#else
+                throw bad_any_cast();
+#endif
+            }
+        }
+    } // namespace detail
+
     class any final
     {
     public:
@@ -378,8 +391,7 @@ namespace xtl
     inline ValueType any_cast(const any& operand)
     {
         auto p = any_cast<typename std::add_const<typename std::remove_reference<ValueType>::type>::type>(&operand);
-        if (p == nullptr)
-            throw bad_any_cast();
+        detail::check_any_cast(p);
         return *p;
     }
 
@@ -388,8 +400,7 @@ namespace xtl
     inline ValueType any_cast(any& operand)
     {
         auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
-        if (p == nullptr)
-            throw bad_any_cast();
+        detail::check_any_cast(p);
         return *p;
     }
 
@@ -414,8 +425,7 @@ namespace xtl
 #endif
 
         auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
-        if (p == nullptr)
-            throw bad_any_cast();
+        detail::check_any_cast(p);
         return detail::any_cast_move_if_true<ValueType>(p, can_move());
     }
 

--- a/include/xtl/xbasic_fixed_string.hpp
+++ b/include/xtl/xbasic_fixed_string.hpp
@@ -21,6 +21,7 @@
 #endif
 
 #include "xhash.hpp"
+#include "xtl_config.hpp"
 
 namespace xtl
 {

--- a/include/xtl/xbasic_fixed_string.hpp
+++ b/include/xtl/xbasic_fixed_string.hpp
@@ -675,7 +675,12 @@ namespace xtl
                 {
                     std::ostringstream oss;
                     oss << "Invalid size (" << size << ") for xbasic_fixed_string - maximal size: " << N;
+#if defined(XTL_NO_EXCEPTIONS)
+                    std::fprintf(stderr, "%s\n", oss.str().c_str());
+                    std::terminate();
+#else
                     throw std::length_error(oss.str());
+#endif
                 }
                 return size;
             }
@@ -1933,7 +1938,12 @@ namespace xtl
     {
         if (pos >= size)
         {
+#if defined(XTL_NO_EXCEPTIONS)
+            std::fprintf(stderr, "%s\n", what);
+            std::terminate();
+#else
             throw std::out_of_range(what);
+#endif
         }
     }
 

--- a/include/xtl/xcomplex_sequence.hpp
+++ b/include/xtl/xcomplex_sequence.hpp
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <vector>
+#include <algorithm>
 
 #include "xclosure.hpp"
 #include "xcomplex.hpp"

--- a/include/xtl/xdynamic_bitset.hpp
+++ b/include/xtl/xdynamic_bitset.hpp
@@ -253,7 +253,12 @@ namespace xtl
     inline void xdynamic_bitset_view<X>::resize(std::size_t sz)
     {
         if (sz != this->m_size) {
+#if defined(XTL_NO_EXCEPTIONS)
+            std::fprintf(stderr, "cannot resize bitset_view\n");
+            std::terminate();        
+#else
             throw std::runtime_error("cannot resize bitset_view");
+#endif
         }
     }
 

--- a/include/xtl/xmasked_value_meta.hpp
+++ b/include/xtl/xmasked_value_meta.hpp
@@ -10,6 +10,8 @@
 #ifndef XTL_XMASKED_VALUE_META_HPP
 #define XTL_XMASKED_VALUE_META_HPP
 
+#include <type_traits>
+
 namespace xtl
 {
     template <class T, class B = bool>

--- a/include/xtl/xmeta_utils.hpp
+++ b/include/xtl/xmeta_utils.hpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 
 #include "xfunctional.hpp"
+#include "xtl_config.hpp"
 
 namespace xtl
 {

--- a/include/xtl/xtl_config.hpp
+++ b/include/xtl/xtl_config.hpp
@@ -13,11 +13,16 @@
 #define XTL_VERSION_MINOR 6
 #define XTL_VERSION_PATCH 1
 
-// Attempt to discover whether we're being compiled with exception support
-#ifndef XTL_NO_EXCEPTIONS
-#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
-#define XTL_NO_EXCEPTIONS
+#ifndef __has_feature
+#define __has_feature(x) 0
 #endif
+
+// Attempt to discover whether we're being compiled with exception support
+#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(XTL_NO_EXCEPTIONS)
+// Exceptions are enabled.
+#else
+// Exceptions are disabled.
+#define XTL_NO_EXCEPTIONS
 #endif
 
 #endif

--- a/include/xtl/xtl_config.hpp
+++ b/include/xtl/xtl_config.hpp
@@ -13,4 +13,11 @@
 #define XTL_VERSION_MINOR 6
 #define XTL_VERSION_PATCH 1
 
+// Attempt to discover whether we're being compiled with exception support
+#ifndef XTL_NO_EXCEPTIONS
+#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#define XTL_NO_EXCEPTIONS
+#endif
+#endif
+
 #endif

--- a/include/xtl/xvariant.hpp
+++ b/include/xtl/xvariant.hpp
@@ -9,14 +9,7 @@
 #ifndef XTL_XVARIANT_HPP
 #define XTL_XVARIANT_HPP
 
-#ifndef __cpp_exceptions
-    #define __cpp_exceptions
-    #include "xvariant_impl.hpp"
-    #undef __cpp_exceptions
-#else
-    #include "xvariant_impl.hpp"
-#endif
-
+#include "xvariant_impl.hpp"
 #include "xclosure.hpp"
 #include "xmeta_utils.hpp"
 

--- a/include/xtl/xvariant_impl.hpp
+++ b/include/xtl/xvariant_impl.hpp
@@ -267,9 +267,13 @@ namespace std {
 #define MPARK_CPP14_CONSTEXPR
 #endif
 
-#if __has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
-    (defined(_MSC_VER) && defined(_CPPUNWIND))
-#define MPARK_EXCEPTIONS
+#if !defined(MPARK_NO_EXCEPTIONS) && \
+    (__has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
+    defined(__EXCEPTIONS) || (defined(_MSC_VER) && defined(_CPPUNWIND)))
+// Exceptions are enabled.
+#else
+// Exceptions are disabled.
+#define MPARK_NO_EXCEPTIONS
 #endif
 
 #if defined(__cpp_generic_lambdas) || defined(_MSC_VER)
@@ -910,7 +914,7 @@ namespace mpark {
   };
 
   [[noreturn]] inline void throw_bad_variant_access() {
-#ifdef MPARK_EXCEPTIONS
+#if !defined(MPARK_NO_EXCEPTIONS)
     throw bad_variant_access{};
 #else
     std::terminate();
@@ -2127,7 +2131,7 @@ namespace mpark {
             std::swap(lhs, rhs);
           }
           impl tmp(lib::move(*rhs));
-#ifdef MPARK_EXCEPTIONS
+#if !defined(MPARK_NO_EXCEPTIONS)
           // EXTENSION: When the move construction of `lhs` into `rhs` throws
           // and `tmp` is nothrow move constructible then we move `tmp` back
           // into `rhs` and provide the strong exception safety guarantee.

--- a/include/xtl/xvariant_impl.hpp
+++ b/include/xtl/xvariant_impl.hpp
@@ -271,9 +271,7 @@ namespace std {
     (__has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
     defined(__EXCEPTIONS) || (defined(_MSC_VER) && defined(_CPPUNWIND)))
 // Exceptions are enabled.
-#else
-// Exceptions are disabled.
-#define MPARK_NO_EXCEPTIONS
+#define MPARK_EXCEPTIONS
 #endif
 
 #if defined(__cpp_generic_lambdas) || defined(_MSC_VER)
@@ -914,7 +912,7 @@ namespace mpark {
   };
 
   [[noreturn]] inline void throw_bad_variant_access() {
-#if !defined(MPARK_NO_EXCEPTIONS)
+#ifdef MPARK_EXCEPTIONS
     throw bad_variant_access{};
 #else
     std::terminate();
@@ -2131,7 +2129,7 @@ namespace mpark {
             std::swap(lhs, rhs);
           }
           impl tmp(lib::move(*rhs));
-#if !defined(MPARK_NO_EXCEPTIONS)
+#ifdef MPARK_EXCEPTIONS
           // EXTENSION: When the move construction of `lhs` into `rhs` throws
           // and `tmp` is nothrow move constructible then we move `tmp` back
           // into `rhs` and provide the strong exception safety guarantee.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,11 +36,17 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Clang OR CMAKE_CXX_COMPILER_ID MATCHES GNU OR C
     if (HAS_MARCH_NATIVE)
         add_compile_options(-march=native)
     endif()
+    if (XTL_DISABLE_EXCEPTIONS)
+        add_compile_options(-fno-exceptions)
+    endif()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
     add_compile_options(/EHsc /MP /bigobj)
     set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
+    if (XTL_DISABLE_EXCEPTIONS)
+        add_compile_options(/EHs-c-)
+    endif()
 endif()
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)

--- a/test/test_xbase64.cpp
+++ b/test/test_xbase64.cpp
@@ -6,11 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtl/xbase64.hpp"
 
 #include <complex>
 
-#include "xtl/xbase64.hpp"
+#include "gtest/gtest.h"
+
 
 namespace xtl
 {

--- a/test/test_xbasic_fixed_string.cpp
+++ b/test/test_xbasic_fixed_string.cpp
@@ -6,13 +6,15 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 
 #include "xtl/xbasic_fixed_string.hpp"
 
 #ifdef HAVE_NLOHMANN_JSON
 #include "xtl/xjson.hpp"
 #endif
+
+#include "gtest/gtest.h"
+#include "xtl/xtl_config.hpp"
 
 namespace xtl
 {
@@ -170,7 +172,11 @@ namespace xtl
             s.assign(size_type(4), 'a');
             EXPECT_EQ(s.size(), size_type(4));
             EXPECT_STREQ(s.c_str(), "aaaa");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.assign(size_type(17), 'a'), "");
+#else
             EXPECT_THROW(s.assign(size_type(17), 'a'), std::length_error);
+#endif
         }
 
         // From substring
@@ -190,7 +196,11 @@ namespace xtl
             EXPECT_EQ(s.size(), size_type(12));
             EXPECT_STREQ(s.c_str(), "construc");
             const char* ctothrow = "abcdefghij\0klmnopq";
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.assign(ctothrow, size_type(18)), "");
+#else
             EXPECT_THROW(s.assign(ctothrow, size_type(18)), std::length_error);
+#endif
         }
 
         // From const char*
@@ -201,7 +211,11 @@ namespace xtl
             EXPECT_EQ(s.size(), size_type(11));
             EXPECT_STREQ(s.c_str(), cstr);
             const char* ctothrow = "abcdefghijklmnopq";
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.assign(ctothrow, size_type(17)), "");
+#else
             EXPECT_THROW(s.assign(ctothrow, size_type(17)), std::length_error);
+#endif
         }
 
         // From initializer_list
@@ -210,7 +224,11 @@ namespace xtl
             s.assign({ 'c', 'o', 'n', 's', 't' });
             EXPECT_EQ(s.size(), size_type(5));
             EXPECT_STREQ(s.c_str(), "const");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.assign({ 'a','b','c','a','b','c','a','b','c','a','b','c','a','b','c','a','b','c' }), "");
+#else
             EXPECT_THROW(s.assign({ 'a','b','c','a','b','c','a','b','c','a','b','c','a','b','c','a','b','c' }), std::length_error);
+#endif
         }
 
         // From iterators pair
@@ -221,7 +239,11 @@ namespace xtl
             EXPECT_EQ(s.size(), size_type(11));
             EXPECT_STREQ(s.c_str(), s1.c_str());
             std::string ctothrow = "abcdefghijklmnopq";
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.assign(ctothrow.cbegin(), ctothrow.cend()), "");
+#else
             EXPECT_THROW(s.assign(ctothrow.cbegin(), ctothrow.cend()), std::length_error);
+#endif
         }
 
         // From lvalue reference
@@ -275,7 +297,11 @@ namespace xtl
         EXPECT_EQ(s.back(), 'S');
         EXPECT_STREQ(s.c_str(), "ElEMent_accesS");
 
+#if defined(XTL_NO_EXCEPTIONS)
+        EXPECT_DEATH_IF_SUPPORTED(s.at(15), "");
+#else
         EXPECT_THROW(s.at(15), std::out_of_range);
+#endif
 
         EXPECT_STREQ(s.data(), s.c_str());
     }
@@ -343,7 +369,11 @@ namespace xtl
         EXPECT_STREQ(s1.c_str(), "erati");
         string_type s2 = ref.substr(2, 45);
         EXPECT_STREQ(s2.c_str(), "eration");
+#if defined(XTL_NO_EXCEPTIONS)
+        EXPECT_DEATH_IF_SUPPORTED(ref.substr(15, 4), "");
+#else
         EXPECT_THROW(ref.substr(15, 4), std::out_of_range);
+#endif
     }
 
     TEST(xfixed_string, copy)
@@ -360,7 +390,11 @@ namespace xtl
         EXPECT_EQ(cp2, size_type(6));
         EXPECT_STREQ(dst2.c_str(), "ration");
 
+#if defined(XTL_NO_EXCEPTIONS)
+        EXPECT_DEATH_IF_SUPPORTED(ref.copy(dst2.data(), 4, 15), "");
+#else
         EXPECT_THROW(ref.copy(dst2.data(), 4, 15), std::out_of_range);
+#endif
     }
 
     TEST(xfixed_string, resize)
@@ -397,14 +431,22 @@ namespace xtl
             string_type s = ref;
             s.insert(3, 2, 'a');
             EXPECT_STREQ(s.c_str(), "opeaaration");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.insert(45, 2, 'b'), "");
+#else
             EXPECT_THROW(s.insert(45, 2, 'b'), std::out_of_range);
+#endif
         }
 
         {
             string_type s = ref;
             s.insert(3, "bb");
             EXPECT_STREQ(s.c_str(), "opebbration");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.insert(45, "bb"), "");
+#else
             EXPECT_THROW(s.insert(45, "bb"), std::out_of_range);
+#endif
         }
 
         {
@@ -412,7 +454,11 @@ namespace xtl
             s.insert(3, "b\0b", 3);
             EXPECT_EQ(s.size(), size_type(12));
             EXPECT_STREQ(s.c_str(), "opeb");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.insert(45, "b\0b", 3), "");
+#else
             EXPECT_THROW(s.insert(45, "b\0b", 3), std::out_of_range);
+#endif
         }
 
         {
@@ -420,7 +466,11 @@ namespace xtl
             string_type ins = "aa";
             s.insert(3, ins);
             EXPECT_STREQ(s.c_str(), "opeaaration");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.insert(45, ins), "");
+#else
             EXPECT_THROW(s.insert(45, ins), std::out_of_range);
+#endif
         }
 
         {
@@ -430,7 +480,11 @@ namespace xtl
             EXPECT_STREQ(s.c_str(), "opecdration");
             s.insert(3, ins, 5, 15);
             EXPECT_STREQ(s.c_str(), "opefghcdration");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.insert(45, ins, 2, 2), "");
+#else
             EXPECT_THROW(s.insert(45, ins, 2, 2), std::out_of_range);
+#endif
         }
 
         {
@@ -438,7 +492,11 @@ namespace xtl
             std::string ins = "aa";
             s.insert(3, ins);
             EXPECT_STREQ(s.c_str(), "opeaaration");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.insert(45, ins), "");
+#else
             EXPECT_THROW(s.insert(45, ins), std::out_of_range);
+#endif
         }
 
         {
@@ -448,7 +506,11 @@ namespace xtl
             EXPECT_STREQ(s.c_str(), "opecdration");
             s.insert(3, ins, 5, 15);
             EXPECT_STREQ(s.c_str(), "opefghcdration");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.insert(45, ins, 2, 2), "");
+#else
             EXPECT_THROW(s.insert(45, ins, 2, 2), std::out_of_range);
+#endif
         }
 
         {
@@ -510,7 +572,11 @@ namespace xtl
             string_type s = ref;
             s.append(2, 'a');
             EXPECT_STREQ(s.c_str(), "operationaa");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.append(15, 'a'), "");
+#else
             EXPECT_THROW(s.append(15, 'a'), std::length_error);
+#endif
         }
 
         {
@@ -518,7 +584,11 @@ namespace xtl
             string_type ap = "abc";
             s.append(ap);
             EXPECT_STREQ(s.c_str(), "operationabc");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.append(string_type("operation")), "");
+#else
             EXPECT_THROW(s.append(string_type("operation")), std::length_error);
+#endif
         }
 
         {
@@ -535,7 +605,11 @@ namespace xtl
             std::string ap = "abc";
             s.append(ap);
             EXPECT_STREQ(s.c_str(), "operationabc");
+#if defined(XTL_NO_EXCEPTIONS)
+            EXPECT_DEATH_IF_SUPPORTED(s.append(string_type("operation")), "");
+#else
             EXPECT_THROW(s.append(string_type("operation")), std::length_error);
+#endif
         }
 
         {
@@ -1126,7 +1200,11 @@ namespace xtl
         EXPECT_EQ(s.back(), 'S');
         EXPECT_STREQ(s.c_str(), "ElEMent_accesS");
 
+#if defined(XTL_NO_EXCEPTIONS)
+        EXPECT_DEATH_IF_SUPPORTED(s.at(15), "");
+#else
         EXPECT_THROW(s.at(15), std::out_of_range);
+#endif
 
         EXPECT_STREQ(s.data(), s.c_str());
         EXPECT_STREQ(s.data(), buf);

--- a/test/test_xclosure.cpp
+++ b/test/test_xclosure.cpp
@@ -6,12 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtl/xclosure.hpp"
 
 #include <type_traits>
 #include <vector>
 
-#include "xtl/xclosure.hpp"
+#include "gtest/gtest.h"
 
 namespace xtl
 {

--- a/test/test_xcomplex.cpp
+++ b/test/test_xcomplex.cpp
@@ -6,11 +6,11 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtl/xcomplex.hpp"
 
 #include <complex>
 
-#include "xtl/xcomplex.hpp"
+#include "gtest/gtest.h"
 #include "xtl/xclosure.hpp"
 
 namespace xtl

--- a/test/test_xcomplex_sequence.cpp
+++ b/test/test_xcomplex_sequence.cpp
@@ -6,9 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
 #include "xtl/xcomplex_sequence.hpp"
+
+#include "gtest/gtest.h"
 
 namespace xtl
 {

--- a/test/test_xdynamic_bitset.cpp
+++ b/test/test_xdynamic_bitset.cpp
@@ -6,9 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
 #include "xtl/xdynamic_bitset.hpp"
+
+#include "gtest/gtest.h"
 
 namespace xtl
 {

--- a/test/test_xfunctional.cpp
+++ b/test/test_xfunctional.cpp
@@ -6,10 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
-#include "xtl/xoptional.hpp"
 #include "xtl/xfunctional.hpp"
+
+#include "gtest/gtest.h"
+#include "xtl/xoptional.hpp"
 
 namespace xtl
 {

--- a/test/test_xhash.cpp
+++ b/test/test_xhash.cpp
@@ -6,13 +6,13 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtl/xhash.hpp"
+
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 
 #include "gtest/gtest.h"
-
-#include "xtl/xhash.hpp"
 
 namespace xtl
 {

--- a/test/test_xhierarchy_generator.cpp
+++ b/test/test_xhierarchy_generator.cpp
@@ -6,11 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtl/xhierarchy_generator.hpp"
 
 #include <type_traits>
 
-#include "xtl/xhierarchy_generator.hpp"
+#include "gtest/gtest.h"
+
 
 namespace xtl
 {

--- a/test/test_xiterator_base.cpp
+++ b/test/test_xiterator_base.cpp
@@ -6,6 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtl/xiterator_base.hpp"
+
 #include <list>
 #include <map>
 #include <string>
@@ -13,7 +15,6 @@
 
 #include "gtest/gtest.h"
 
-#include "xtl/xiterator_base.hpp"
 
 namespace adl
 {

--- a/test/test_xmasked_value.cpp
+++ b/test/test_xmasked_value.cpp
@@ -7,10 +7,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
-#include "xtl/xoptional.hpp"
 #include "xtl/xmasked_value.hpp"
+
+#include "gtest/gtest.h"
+#include "xtl/xoptional.hpp"
 
 namespace xtl
 {

--- a/test/test_xmeta_utils.cpp
+++ b/test/test_xmeta_utils.cpp
@@ -5,10 +5,9 @@
 *                                                                          *
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
+#include "xtl/xmeta_utils.hpp"
 
 #include "gtest/gtest.h"
-
-#include "xtl/xmeta_utils.hpp"
 #include "xtl/xvariant.hpp"
 
 namespace xtl

--- a/test/test_xoptional.cpp
+++ b/test/test_xoptional.cpp
@@ -6,7 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtl/xoptional.hpp"
+#include "xtl/xoptional_sequence.hpp"
 
 #include <algorithm>
 #include <sstream>
@@ -14,13 +15,12 @@
 #include <vector>
 
 #include "xtl/xany.hpp"
-#include "xtl/xoptional.hpp"
+#include "gtest/gtest.h"
 
 #ifdef HAVE_NLOHMANN_JSON
 #include "xtl/xjson.hpp"
 #endif
 
-#include "xtl/xoptional_sequence.hpp"
 
 namespace xtl
 {

--- a/test/test_xsequence.cpp
+++ b/test/test_xsequence.cpp
@@ -6,12 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtl/xsequence.hpp"
 
 #include <array>
 #include <vector>
 
-#include "xtl/xsequence.hpp"
+#include "gtest/gtest.h"
 
 namespace xtl
 {

--- a/test/test_xtype_traits.cpp
+++ b/test/test_xtype_traits.cpp
@@ -6,9 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtl/xtype_traits.hpp"
+
 #include "gtest/gtest.h"
 
-#include "xtl/xtype_traits.hpp"
 
 namespace xtl
 {

--- a/test/test_xvariant.cpp
+++ b/test/test_xvariant.cpp
@@ -6,12 +6,13 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtl/xvariant.hpp"
+
 #include <string>
 #include <vector>
 
 #include "gtest/gtest.h"
-
-#include "xtl/xvariant.hpp"
+#include "xtl/xtl_config.hpp"
 
 using namespace std::literals;
 
@@ -36,7 +37,11 @@ namespace xtl
     {
         xtl::variant<int, float> v;
         v = 12;
+#if defined(XTL_NO_EXCEPTIONS)
+        EXPECT_DEATH_IF_SUPPORTED(xtl::get<float>(v), "");
+#else
         EXPECT_THROW(xtl::get<float>(v), xtl::bad_variant_access);
+#endif
     }
 
     TEST(xvariant, converting_constructor)


### PR DESCRIPTION
I'd like to be able to build xtl in an environment which uses -fno-exceptions. 
When exceptions are disabled, std::terminate() is called instead.

1/ add exception detecion to xtl_config.hpp. When exceptions are disabled, the XTL_NO_EXCEPTIONS macro is defined.

2/ in the include/xtl/*.hpp files, guard exception blocks with XTL_NO_EXCEPTIONS, introducing helper functions for some common cases. Removal of the exceptions workaround for xvariant_impl.

3/ Updates to test files so that they all build and run in an -fno-exceptions environment.
Tested via the flag CMAKE_CXX_FLAG = -fno-exceptions. This introduces EXPECT_DEATH_IF_ENABLED in place of EXPECT_THROW macros.

4/ Minor updates to test ordering, specifically:
  4a/ include the primary .hpp target file of the specific test first.
  4b/ add missing includes to the .hpp target file when the test failed.
